### PR TITLE
Disable hover effects globally when using a touch device

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -40,7 +40,7 @@ body {
     overflow-x: hidden;
   }
   // Disable highlight when Touch/Press
-  -webkit-tap-highlight-color:  rgba(255, 255, 255, 0);
+  -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
   margin: 0;
   font-family: NunitoSans-Regular;
   -webkit-font-smoothing: antialiased;
@@ -147,6 +147,15 @@ body {
     }
     .button-blue {
       width: 100%;
+    }
+  }
+}
+
+/* Disable hover effects globally when using a touch device */
+@media (hover: none) {
+  * {
+    :hover {
+      opacity: unset !important;
     }
   }
 }


### PR DESCRIPTION
To avoid the stale opacity on touch devices after clicking an element with an hover effect.