### PR TITLE
CW-373 - fix can't create proposal

### DIFF
--- a/src/containers/Common/components/CommonDetailContainer/AddProposalComponent/AddProposalComponent.tsx
+++ b/src/containers/Common/components/CommonDetailContainer/AddProposalComponent/AddProposalComponent.tsx
@@ -101,12 +101,7 @@ export const AddProposalComponent = ({
 
   const confirmProposal = useCallback(() => {
     changeCreationProposalStep(AddProposalSteps.LOADER);
-    fundingRequest.links = fundingRequest.links?.map((i: any) => {
-      return {
-        title: i.title,
-        value: i.link,
-      };
-    });
+    fundingRequest.links = fundingRequest.links?.filter((link) => link.title && link.value);
     fundingRequest.amount = fundingRequest.amount * 100;
     onProposalAdd(fundingRequest, changeCreationProposalStep);
   }, [onProposalAdd, fundingRequest]);


### PR DESCRIPTION
resolves: #373 
User can't create a proposal due to a bad parse of the `links` property that is sent to the BE.
