### PR TITLE
bug/CW-360 "Continue to payment" button isn't disabling during the immediate payment's execution

### DIFF
--- a/src/containers/Common/components/CommonListContainer/CreateCommonModal/Payment/RequestPayment/RequestPayment.tsx
+++ b/src/containers/Common/components/CommonListContainer/CreateCommonModal/Payment/RequestPayment/RequestPayment.tsx
@@ -82,6 +82,7 @@ export default function RequestPayment(
   ] = useState<State>(INITIAL_STATE);
   const [cards, setUserCards] = useState<Card[]>([]);
   const [hasPaymentMethod, setHasPaymentMethod] = useState<boolean | null>(null);
+  const [isImmediatePaymentLoading, setIsImmediatePaymentLoading] = useState<boolean>(false);
   const screenSize = useSelector(getScreenSize());
   const isMobileView = (screenSize === ScreenSize.Mobile);
   const selectedAmount = paymentData.contributionAmount;
@@ -105,6 +106,8 @@ export default function RequestPayment(
   const makeImmediateContributionRequest = useCallback(() => {
     if (!paymentData.contributionAmount)
       return;
+    
+    setIsImmediatePaymentLoading(true);
 
     dispatch(
       makeImmediateContribution.request({
@@ -243,8 +246,10 @@ export default function RequestPayment(
 
       <div className="create-common-payment__content">
         {
-          (!isPaymentIframeLoaded && !hasPaymentMethod)
-          && <Loader className="create-common-payment__loader" />
+          (
+            (!isPaymentIframeLoaded && !hasPaymentMethod)
+            || isImmediatePaymentLoading
+          ) && <Loader className="create-common-payment__loader" />
         }
         {
           hasPaymentMethod
@@ -266,6 +271,7 @@ export default function RequestPayment(
                 key="request-payment-continue"
                 className="create-common-payment__continue-button"
                 shouldUseFullWidth={isMobileView}
+                disabled={isImmediatePaymentLoading}
                 onClick={makeImmediateContributionRequest}
               >
                 Continue to payment


### PR DESCRIPTION
now looks like this
<img width="897" alt="image" src="https://user-images.githubusercontent.com/36640797/163392547-985eeae9-3037-44c3-8ce3-9fddf1942b1d.png">
