### PR TITLE
CW-467 - fix 422 error when trying to create proposal with 0 amount 

### DIFF
--- a/src/containers/Common/components/CommonDetailContainer/AddProposalComponent/AddProposalComponent.tsx
+++ b/src/containers/Common/components/CommonDetailContainer/AddProposalComponent/AddProposalComponent.tsx
@@ -92,9 +92,10 @@ export const AddProposalComponent = ({
   
   const saveProposalState = useCallback(
     (payload: Partial<CreateFundingRequestProposalPayload>) => {
-      setFundingRequest({ ...fundingRequest, ...payload });
+      const fundingRequestData = { ...fundingRequest, ...payload };
+      setFundingRequest(fundingRequestData);
       if (!payload.amount) {
-        confirmProposal({ ...fundingRequest, ...payload });
+        confirmProposal(fundingRequestData);
       } else {
         changeCreationProposalStep(AddProposalSteps.CONFIRM);
       }


### PR DESCRIPTION
resolves: #467 

Since the state is not updated in the same event loop (need to wait for the next render) so the `fundingRequest` data is sent  directly to the `confirmProposal` function. 