### PR TITLE
CW-468 - Use correct card during request to join

### DIFF
--- a/src/containers/Common/components/CommonDetailContainer/MembershipRequestModal/MembershipRequestPayment.tsx
+++ b/src/containers/Common/components/CommonDetailContainer/MembershipRequestModal/MembershipRequestPayment.tsx
@@ -72,10 +72,15 @@ export default function MembershipRequestPayment(
     [setState]
   );
 
-  const finishPayment = useCallback(
-    () => setUserData((nextUserData) => ({ ...nextUserData, stage: 5 })),
-    [setUserData]
-  );
+  const finishPayment = useCallback(() => {
+    const cardId = hasPaymentMethod && cards[0]?.id;
+
+    setUserData((nextUserData) => ({
+      ...nextUserData,
+      cardId: cardId || nextUserData.cardId,
+      stage: 5,
+    }));
+  }, [setUserData, hasPaymentMethod, cards]);
 
   useEffect(() => {
     dispatch(loadUserCards.request({


### PR DESCRIPTION
The issue in the tickets says that error is during join request after leaving a common. But it happened even without leaving a common, due to wrong card id usage.