### PR TITLE
Updates/fix PaymeTypeCodes enum ; updates to bank details files

### DIFF
--- a/src/containers/Common/components/CommonDetailContainer/AddProposalComponent/AddBankDetails/AddBankDetails.tsx
+++ b/src/containers/Common/components/CommonDetailContainer/AddProposalComponent/AddBankDetails/AddBankDetails.tsx
@@ -228,7 +228,6 @@ export const AddBankDetails = (props: IProps) => {
             : {
                 name: photoIdFileName,
                 legalType: PaymeTypeCodes.SocialId,
-                amount: 2000,
                 mimeType: photoIdFile!.type,
                 downloadURL: values.photoId,
               },
@@ -237,7 +236,6 @@ export const AddBankDetails = (props: IProps) => {
             : {
                 name: bankLetterFileName,
                 legalType: PaymeTypeCodes.BankAccountOwnership,
-                amount: 2000,
                 mimeType: bankLetterFile!.type,
                 downloadURL: values.bankLetter,
               },

--- a/src/shared/interfaces/api/payMe.ts
+++ b/src/shared/interfaces/api/payMe.ts
@@ -5,7 +5,7 @@ export interface BuyerTokenPageCreationData {
 }
 
 export enum PaymeTypeCodes {
-  SocialId, //Social ID document. For additional information see Note 3 above
+  SocialId = 1, //Social ID document. For additional information see Note 3 above
   BankAccountOwnership, //Proof of bank account ownership or a cancelled cheque photo. For additional information see Note 3 above
   CorporateCertificate, //For additional information see Note 3 above
   BankAuthorization, //Bank authorization


### PR DESCRIPTION
- Fix `PaymeTypeCodes` enum to start count from 1 (according payMe it should start from 1 and not from 0 - see here https://docs.payme.io/docs/payments/410244b17fb42-upload-seller-files)
- Remove unnecessary field `amount` while uploading bank documents.