### PR TITLE
Bugfix/CW-577 Sent discussion messages aren't immediately displaying

### DIFF
--- a/src/containers/Common/store/saga.tsx
+++ b/src/containers/Common/store/saga.tsx
@@ -454,11 +454,15 @@ export function* addMessageToDiscussionSaga(
       async (data) => {
         const { discussion } = action.payload;
 
-        discussion.discussionMessage = data.sort(
-          (m: DiscussionMessage, mP: DiscussionMessage) =>
-            m.createTime?.seconds - mP.createTime?.seconds
-        );
-        store.dispatch(actions.loadDisscussionDetail.request(discussion));
+        const updatedDiscussion = {
+          ...discussion,
+          discussionMessage: data.sort(
+            (m: DiscussionMessage, mP: DiscussionMessage) =>
+              m.createTime?.seconds - mP.createTime?.seconds
+          ),
+        };
+
+        store.dispatch(actions.loadDisscussionDetail.request(updatedDiscussion));
         store.dispatch(actions.getCommonsList.request());
       }
     );


### PR DESCRIPTION
resolves: https://github.com/daostack/common-web/issues/577

there was an error:

<img width="1272" alt="image" src="https://user-images.githubusercontent.com/36640797/172667963-383ac065-30c9-4b4e-9f1a-2154ceae5592.png">

...occurring when tried to re-assign a discussion's discussionMessage field (inside of the *addMessageToDiscussionSaga* function):
<img width="391" alt="image" src="https://user-images.githubusercontent.com/36640797/172668304-8436c67c-e103-4c1a-988b-00c31aaefcbf.png">

so the field was "freezed" for a some reason