### PR TITLE
Create common - General info - about - the about field is limited to 200 characters #744

### DIFF
--- a/src/containers/Common/components/CommonListContainer/CreateCommonModal/CreationSteps/GeneralInfo/constants.ts
+++ b/src/containers/Common/components/CommonListContainer/CreateCommonModal/CreationSteps/GeneralInfo/constants.ts
@@ -1,3 +1,3 @@
 export const MAX_COMMON_NAME_LENGTH = 49;
 export const MAX_TAGLINE_LENGTH = 89;
-export const MAX_ABOUT_LENGTH = 200;
+export const MAX_ABOUT_LENGTH = 2000;


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/744

- Changed max about length for General Info