### PR TITLE
CW-789 - Hide proposals from selection if they don't exist in governance

### DIFF
--- a/src/containers/Common/components/CommonDetailContainer/CreateProposalModal/ProposalTypeSelection/ProposalTypeSelection.tsx
+++ b/src/containers/Common/components/CommonDetailContainer/CreateProposalModal/ProposalTypeSelection/ProposalTypeSelection.tsx
@@ -77,24 +77,26 @@ const ProposalTypeSelection: FC<ProposalTypeSelectionProps> = (props) => {
   const isMobileView = screenSize === ScreenSize.Mobile;
   const proposalTypeDetails =
     selectedType && getProposalTypeDetails(governance, selectedType);
-  const proposalTypeOptions = useMemo<ProposalTypeOption[]>(
-    () =>
-      PROPOSAL_TYPE_OPTIONS.map((option) => {
-        const isDisabled = !checkIsProposalTypeAllowedForMember(
-          commonMember,
-          option.value as ProposalsTypes
-        );
+  const proposalTypeOptions = useMemo<ProposalTypeOption[]>(() => {
+    const proposalKeys = Object.keys(governance.proposals);
 
-        return {
-          ...option,
-          isDisabled,
-          className: isDisabled
-            ? "proposal-type-selection-stage__type-dropdown-item--disabled"
-            : "",
-        };
-      }),
-    [commonMember]
-  );
+    return PROPOSAL_TYPE_OPTIONS.filter((option) =>
+      proposalKeys.includes(option.value as string)
+    ).map((option) => {
+      const isDisabled = !checkIsProposalTypeAllowedForMember(
+        commonMember,
+        option.value as ProposalsTypes
+      );
+
+      return {
+        ...option,
+        isDisabled,
+        className: isDisabled
+          ? "proposal-type-selection-stage__type-dropdown-item--disabled"
+          : "",
+      };
+    });
+  }, [governance.proposals, commonMember]);
 
   const handleSelect = (value: unknown) => {
     const foundOption = proposalTypeOptions.find(


### PR DESCRIPTION
- now we do not display in selection proposals which don't exist in the `governance.proposals`.