### PR TITLE
Fix for missing "allowed votes" section

### DIFF
--- a/src/containers/Common/components/CommonDetailContainer/CommonWhitepaper/components/WhitepaperMembers/WhitepaperMembers.tsx
+++ b/src/containers/Common/components/CommonDetailContainer/CommonWhitepaper/components/WhitepaperMembers/WhitepaperMembers.tsx
@@ -81,7 +81,7 @@ export default function WhitepaperMembers() {
         })
       }
 
-      if (governance?.proposals[proposal]?.global?.weights?.find(({ circles }) => circles & circleBin)) {
+      if (governance?.proposals[proposal]?.global?.weights?.find(({ circles }) => circles.bin & circleBin)) {
         return true
       }
     }).map((proposalType) =>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/89919079/192138250-ecf05e99-b02f-4445-8dc9-c05ae6de2c33.png)

The circles parsing probably wasn't caught because inferred type was `any`, it should fix the issue with non "assign/remove circle" proposals