### PR TITLE
Private discussion - Creating discussion for circles higher then permitted #912

### DIFF
--- a/src/containers/Common/components/CommonDetailContainer/AddDiscussionComponent/AddDiscussionComponent.tsx
+++ b/src/containers/Common/components/CommonDetailContainer/AddDiscussionComponent/AddDiscussionComponent.tsx
@@ -159,7 +159,8 @@ const AddDiscussionComponent = ({
               : [nonNullData];
             const finalCircles = addCirclesWithHigherTier(
               currentCircles,
-              circleOptions
+              circleOptions,
+              userCircleIds
             );
             formikProps.setFieldValue("circleVisibility", finalCircles);
           };

--- a/src/shared/utils/circles.spec.ts
+++ b/src/shared/utils/circles.spec.ts
@@ -143,9 +143,16 @@ describe("circlesHierarchy", () => {
         CIRCLES_WITHOUT_EXCLUSION[4],
         CIRCLES_WITHOUT_EXCLUSION[5],
       ];
+      const allowedCircleIds = CIRCLES_WITH_EXCLUSION.map(
+        (circle) => circle.id
+      );
 
       expect(
-        addCirclesWithHigherTier(currentCircles, CIRCLES_WITHOUT_EXCLUSION)
+        addCirclesWithHigherTier(
+          currentCircles,
+          CIRCLES_WITHOUT_EXCLUSION,
+          allowedCircleIds
+        )
       ).toEqual(expectedResult);
     });
 
@@ -163,9 +170,40 @@ describe("circlesHierarchy", () => {
         CIRCLES_WITH_EXCLUSION[5],
         CIRCLES_WITH_EXCLUSION[8],
       ];
+      const allowedCircleIds = CIRCLES_WITH_EXCLUSION.map(
+        (circle) => circle.id
+      );
 
       expect(
-        addCirclesWithHigherTier(currentCircles, CIRCLES_WITH_EXCLUSION)
+        addCirclesWithHigherTier(
+          currentCircles,
+          CIRCLES_WITH_EXCLUSION,
+          allowedCircleIds
+        )
+      ).toEqual(expectedResult);
+    });
+
+    it("should return correct circles with restricted allowed circle ids", () => {
+      const currentCircles = [
+        CIRCLES_WITH_EXCLUSION[0],
+        CIRCLES_WITH_EXCLUSION[4],
+      ];
+      const expectedResult = [];
+      const allowedCircleIds = [
+        CIRCLES_WITH_EXCLUSION[1],
+        CIRCLES_WITH_EXCLUSION[2],
+        CIRCLES_WITH_EXCLUSION[3],
+        CIRCLES_WITH_EXCLUSION[5],
+        CIRCLES_WITH_EXCLUSION[6],
+        CIRCLES_WITH_EXCLUSION[7],
+      ].map((circle) => circle.id);
+
+      expect(
+        addCirclesWithHigherTier(
+          currentCircles,
+          CIRCLES_WITH_EXCLUSION,
+          allowedCircleIds
+        )
       ).toEqual(expectedResult);
     });
   });

--- a/src/shared/utils/circles.ts
+++ b/src/shared/utils/circles.ts
@@ -159,10 +159,15 @@ export const addCirclesWithHigherTier = <
   T extends Pick<Circle, "id" | "hierarchy">
 >(
   currentCircles: T[],
-  allCircles: T[]
-): T[] =>
-  allCircles.filter((circleToCheck) => {
-    const isInCurrentCircles = currentCircles.some(
+  allCircles: T[],
+  allowedCircleIds: string[] = []
+): T[] => {
+  const allowedCurrentCircles = currentCircles.filter((circle) =>
+    allowedCircleIds.includes(circle.id)
+  );
+
+  return allCircles.filter((circleToCheck) => {
+    const isInCurrentCircles = allowedCurrentCircles.some(
       (circle) => circle.id === circleToCheck.id
     );
     if (isInCurrentCircles) {
@@ -172,7 +177,7 @@ export const addCirclesWithHigherTier = <
       return false;
     }
 
-    return currentCircles.some(
+    return allowedCurrentCircles.some(
       (circle) =>
         circle.hierarchy &&
         circleToCheck.hierarchy &&
@@ -181,3 +186,4 @@ export const addCirclesWithHigherTier = <
         !circle.hierarchy.exclusions.includes(circleToCheck.hierarchy.tier)
     );
   });
+};


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] deselecting all allowed circles will deselect all not allowed ones

### How to test?
- [ ] open discussion creation modal
- [ ] select `Limited circles` switch
- [ ] select all allowed circles (which are not grayed)
- [ ] you should see that were automatically selected not allowed circles with higher index
- [ ] deselect all allowed circles
- [ ] all not allowed circles should also be deselected
