### PR TITLE
Create discussion - regular discussion appears as Limited #913

### DIFF
--- a/src/shared/utils/circles.ts
+++ b/src/shared/utils/circles.ts
@@ -3,13 +3,10 @@ import { Circle } from "../models";
 
 export const getFilteredByIdCircles = (
   circles: Circle[] | null,
-  circleIds?: string[]
+  circleIds: string[] = []
 ): Circle[] => {
-  if (!circles || circles.length === 0) {
+  if (!circles || circles.length === 0 || circleIds.length === 0) {
     return [];
-  }
-  if (!circleIds || circleIds.length === 0) {
-    return [...circles];
   }
 
   return circles.filter(({ id }) => circleIds.includes(id));


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fixed `getFilteredByIdCircles` util logic. now even if circle ids is not passed or is empty array then we still will receive empty array as result

### How to test?
- [ ] create discussion (do not select `Limited discussion`)
- [ ] see that there is no restrictions by circles in the discussion
