### PR TITLE
Members info pop-up - modifications to commons list #907

### DIFF
--- a/src/containers/Common/components/CommonDetailContainer/MembersComponent/CommonMemberPreview.tsx
+++ b/src/containers/Common/components/CommonDetailContainer/MembersComponent/CommonMemberPreview.tsx
@@ -1,11 +1,11 @@
 import React, { FC, useState, useEffect, useCallback, useMemo } from "react";
+import { getCommonMemberInfo } from "@/containers/Common/store/api";
+import { getCountryNameFromCode } from "@/shared/assets/countries";
 import { UserAvatar, Modal, Loader } from "@/shared/components";
 import {
   CommonMemberPreviewInfo,
   CommonMemberWithUserInfo,
 } from "@/shared/models";
-import { getCommonMemberInfo } from "@/containers/Common/store/api";
-import { getCountryNameFromCode } from "@/shared/assets/countries";
 import {
   getCirclesWithHighestTier,
   getFilteredByIdCircles,
@@ -37,7 +37,7 @@ export const CommonMemberPreview: FC<CommonMemberPreview> = (props) => {
     about,
   } = props;
   const [previewInfo, setPreviewInfo] = useState<CommonMemberPreviewInfo>(
-    {} as CommonMemberPreviewInfo
+    {} as CommonMemberPreviewInfo,
   );
   const [isLoading, setLoading] = useState(true);
   const commonsInfo = useMemo(() => {
@@ -51,7 +51,7 @@ export const CommonMemberPreview: FC<CommonMemberPreview> = (props) => {
         const circleIds = Object.values(common.circlesMap || {});
         const filteredByIdCircles = getFilteredByIdCircles(
           governanceCircles,
-          circleIds
+          circleIds,
         );
         const userCircleNames = getCirclesWithHighestTier(filteredByIdCircles)
           .map(({ name }) => name)
@@ -64,7 +64,7 @@ export const CommonMemberPreview: FC<CommonMemberPreview> = (props) => {
           commonInfo.id === commonId
             ? [commonInfo, ...acc]
             : [...acc, commonInfo],
-        []
+        [],
       );
   }, [previewInfo, commonId]);
 
@@ -73,7 +73,7 @@ export const CommonMemberPreview: FC<CommonMemberPreview> = (props) => {
       (async () => {
         const commonMemberPreviewInfo = await getCommonMemberInfo(
           member.userId,
-          commonId
+          commonId,
         );
         setPreviewInfo(commonMemberPreviewInfo);
         setLoading(false);
@@ -108,7 +108,10 @@ export const CommonMemberPreview: FC<CommonMemberPreview> = (props) => {
           Member of the following Commons
         </p>
         {commonsInfo.map((commonInfo) => (
-          <div key={commonInfo.id} className="common-member-preview__info">
+          <div
+            key={commonInfo.id}
+            className="common-member-preview__common-name"
+          >
             {commonInfo.name} - {commonInfo.userCircleNames}
             {commonInfo.id === commonId && " (current)"}
           </div>

--- a/src/containers/Common/components/CommonDetailContainer/MembersComponent/common-member-preview.scss
+++ b/src/containers/Common/components/CommonDetailContainer/MembersComponent/common-member-preview.scss
@@ -67,11 +67,8 @@
   color: $secondary-blue;
 }
 
-.common-member-preview__common-name-link {
-  font-family: NunitoSans, sans-serif;
-  font-style: normal;
-  font-weight: 400;
-  font-size: $small;
-  line-height: 1.25rem;
-  color: $purple-2;
+.common-member-preview__common-name {
+  @extend .common-member-preview__info;
+
+  margin-bottom: 1.125rem;
 }


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] added margin to member's common names in the preview modal

### How to test?
- [ ] open a common member preview
- [ ] check that there is a vertical margin between common names
