### PR TITLE
Add flag to member admittance during supporters flow #935

### DIFF
--- a/src/containers/Common/components/SupportersContainer/MemberAdmittanceStep/MemberAdmittanceStep.tsx
+++ b/src/containers/Common/components/SupportersContainer/MemberAdmittanceStep/MemberAdmittanceStep.tsx
@@ -7,10 +7,10 @@ import { useCommonMember } from "@/containers/Common/hooks";
 import { createMemberAdmittanceProposal } from "@/containers/Common/store/actions";
 import { subscribeToCommonMembers } from "@/containers/Common/store/api";
 import { Loader } from "@/shared/components";
+import { ErrorText } from "@/shared/components/Form";
+import { useLoadingState } from "@/shared/hooks";
 import { MemberAdmittance } from "@/shared/models/governance/proposals";
 import { getUserName } from "@/shared/utils";
-import { useLoadingState } from "@/shared/hooks";
-import { ErrorText } from "@/shared/components/Form";
 import { GeneralInfoWrapper } from "../GeneralInfoWrapper";
 import "./index.scss";
 
@@ -85,6 +85,7 @@ const MemberAdmittanceStep: FC<MemberAdmittanceStepProps> = (props) => {
               links: [],
               feeMonthly: null,
               feeOneTime: null,
+              fromSupportersFlow: true,
             },
           },
           callback: (error, proposal) => {
@@ -99,7 +100,7 @@ const MemberAdmittanceStep: FC<MemberAdmittanceStepProps> = (props) => {
               data: proposal,
             });
           },
-        })
+        }),
       );
     })();
   }, [

--- a/src/containers/Common/interfaces/CreateProposalPayload.ts
+++ b/src/containers/Common/interfaces/CreateProposalPayload.ts
@@ -20,6 +20,7 @@ interface CreateMemberAdmittance {
     contributionSourceType?: ContributionSourceType;
     feeMonthly: PaymentAmount | null;
     feeOneTime: PaymentAmount | null;
+    fromSupportersFlow?: boolean;
   };
 }
 

--- a/src/shared/models/governance/proposals/MemberAdmittance.ts
+++ b/src/shared/models/governance/proposals/MemberAdmittance.ts
@@ -1,8 +1,8 @@
 import firebase from "firebase/app";
 import { ProposalsTypes } from "@/shared/constants";
+import { PaymentAmount } from "@/shared/models/Payment";
 import { BaseProposal } from "./BaseProposal";
 import { BasicArgsProposal } from "./BasicArgsProposal";
-import { PaymentAmount } from "@/shared/models/Payment";
 
 export interface MemberAdmittanceArgs extends BasicArgsProposal {
   circle?: string;


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] added `fromSupportersFlow` arg to member admittance creation type
- [x] now we are passing `fromSupportersFlow: true` during member admittance proposal creation in supporters flow

### How to test?
- [ ] go to a supporters flow of a common you where you are not a member
- [ ] walk through the steps until payment
- [ ] check that there is a record in the `supportersFlowTracker` for your member admittance proposal
- [ ] try to join a common
- [ ] verify that for usual member admittance flow you do not see a new record in the `supportersFlowTracker` for new member admittance proposal
