### PR TITLE
Fix setup imports order

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -12,6 +12,7 @@
   "arrowParens": "always",
   "proseWrap": "preserve",
   "importOrder": [
+    "/projectSetupImports$",
     "^react(.*)$",
     "<THIRD_PARTY_MODULES>",
     "^@(?!/)(.*)$",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
+import "./projectSetupImports";
 import React from "react";
 import ReactDOM from "react-dom";
 import AppWrapper from "@/pages/App/AppWrapper";
-import "./i18n";
-import "./index.scss";
 
 ReactDOM.render(<AppWrapper />, document.getElementById("root"));

--- a/src/projectSetupImports.ts
+++ b/src/projectSetupImports.ts
@@ -1,0 +1,2 @@
+import "./i18n";
+import "./index.scss";


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/928

### What was changed?
- [x] due to the setup imports order cascading css classed order was changed and it lead to some issues. So I moved setup imports to a file and made it to be the first import in the `index` file of our project.
