### PR TITLE
Supporters flow - Send additional fields to BE #1006

### DIFF
--- a/src/pages/OldCommon/components/SupportersContainer/MemberAdmittanceStep/MemberAdmittanceStep.tsx
+++ b/src/pages/OldCommon/components/SupportersContainer/MemberAdmittanceStep/MemberAdmittanceStep.tsx
@@ -86,6 +86,8 @@ const MemberAdmittanceStep: FC<MemberAdmittanceStepProps> = (props) => {
               feeMonthly: null,
               feeOneTime: null,
               fromSupportersFlow: true,
+              receiveEmails: data.marketingContentAgreement ?? false,
+              userWhatsapp: data.whatsappGroupAgreement ?? false,
             },
           },
           callback: (error, proposal) => {

--- a/src/pages/OldCommon/interfaces/CreateProposalPayload.ts
+++ b/src/pages/OldCommon/interfaces/CreateProposalPayload.ts
@@ -21,6 +21,8 @@ interface CreateMemberAdmittance {
     feeMonthly: PaymentAmount | null;
     feeOneTime: PaymentAmount | null;
     fromSupportersFlow?: boolean;
+    receiveEmails?: boolean;
+    userWhatsapp?: boolean;
   };
 }
 


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/1006

### What was changed?
- Added receiveEmails and userWhatsapp to memberAdmittance
### How to test?
- Try supporters flow and check network in devtools memberAdmittance payload should have receiveEmails and userWhatsapp
