### PR TITLE
Make tabs and breadcrumbs sticky #1076

### DIFF
--- a/src/pages/common/components/CommonContent/CommonContent.module.scss
+++ b/src/pages/common/components/CommonContent/CommonContent.module.scss
@@ -7,7 +7,7 @@
   --bottom-tabs-pb: var(--safe-area-inset-bottom);
 
   flex: 1;
-  padding: 3rem 0;
+  padding-bottom: 3rem;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
@@ -15,8 +15,23 @@
   @include tablet {
     --main-content-mw: 100%;
 
-    padding: 1.25rem 0
-      calc(3.125rem + var(--bottom-tabs-height) + var(--bottom-tabs-pb));
+    padding-bottom: calc(
+      3.125rem + var(--bottom-tabs-height) + var(--bottom-tabs-pb)
+    );
+  }
+}
+
+.contentHeaderWrapper {
+  position: sticky;
+  top: 0;
+  padding-top: 3rem;
+  background-color: var(--page-bg-color);
+
+  @include tablet {
+    position: static;
+    top: unset;
+    padding-top: 1.25rem;
+    background-color: transparent;
   }
 }
 

--- a/src/pages/common/components/CommonContent/CommonContent.tsx
+++ b/src/pages/common/components/CommonContent/CommonContent.tsx
@@ -69,30 +69,32 @@ const CommonContent: FC<CommonContentProps> = (props) => {
       />
       {!isCommonMemberFetched && <Loader variant={LoaderVariant.Global} />}
       <div className={styles.container}>
-        <Container>
-          <CommonHeader
-            commonImageSrc={common.image}
-            commonName={common.name}
-            description={common.byline}
-            details={getMainCommonDetails(common)}
-            isProject={Boolean(common.directParent)}
-            withJoin={false}
-          />
-        </Container>
-        <div className={styles.commonHeaderSeparator} />
-        {!isTabletView && (
+        <div className={styles.contentHeaderWrapper}>
           <Container>
-            <CommonManagement
-              commonId={common.id}
-              activeTab={tab}
-              isSubCommon={isSubCommon}
-              circles={governance.circles}
-              commonMember={commonMember}
-              isAuthenticated={isAuthenticated}
-              onTabChange={setTab}
+            <CommonHeader
+              commonImageSrc={common.image}
+              commonName={common.name}
+              description={common.byline}
+              details={getMainCommonDetails(common)}
+              isProject={Boolean(common.directParent)}
+              withJoin={false}
             />
           </Container>
-        )}
+          <div className={styles.commonHeaderSeparator} />
+          {!isTabletView && (
+            <Container>
+              <CommonManagement
+                commonId={common.id}
+                activeTab={tab}
+                isSubCommon={isSubCommon}
+                circles={governance.circles}
+                commonMember={commonMember}
+                isAuthenticated={isAuthenticated}
+                onTabChange={setTab}
+              />
+            </Container>
+          )}
+        </div>
         <CommonTabPanels
           activeTab={tab}
           common={common}

--- a/src/shared/layouts/SidenavLayout/SidenavLayout.module.scss
+++ b/src/shared/layouts/SidenavLayout/SidenavLayout.module.scss
@@ -14,7 +14,7 @@
   --sb-shadow: 0.125rem 0 0.375rem #{$c-sidebar-shadow};
   --sb-easing: cubic-bezier(0.16, 1, 0.3, 1);
   --sb-transition-duration: 0.6s;
-  --bg-color: #{$c-shades-100};
+  --page-bg-color: #{$c-shades-100};
   --scroll-bg-color: #{$c-shades-white};
   --scroll-thumb-color: #{$c-neutrals-200};
 
@@ -22,7 +22,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  background-color: var(--bg-color);
+  background-color: var(--page-bg-color);
   box-sizing: border-box;
 
   @include tablet {
@@ -54,5 +54,5 @@
   padding-left: var(--main-pl);
   display: flex;
   flex-direction: column;
-  background-color: var(--bg-color);
+  background-color: var(--page-bg-color);
 }


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] made common content header (header and tabs) to be sticky to top of the page

### How to test?
- [ ] open new ui on desktop and see when the page is scrolling that the header is on the sticky to top and everything looks find
- [ ] on mobile everything should work/look as it was previously
