### PR TITLE
Guest Mode - Hide tabs #1115

### DIFF
--- a/src/pages/common/components/CommonContent/CommonContent.tsx
+++ b/src/pages/common/components/CommonContent/CommonContent.tsx
@@ -121,6 +121,7 @@ const CommonContent: FC<CommonContentProps> = (props) => {
             className={styles.tabs}
             activeTab={tab}
             isAuthenticated={isAuthenticated}
+            commonMember={commonMember}
             onTabChange={setTab}
           />
         )}

--- a/src/pages/common/components/CommonManagement/CommonManagement.tsx
+++ b/src/pages/common/components/CommonManagement/CommonManagement.tsx
@@ -34,6 +34,7 @@ const CommonManagement: FC<CommonManagementProps> = (props) => {
         className={styles.tabs}
         activeTab={activeTab}
         isAuthenticated={isAuthenticated}
+        commonMember={commonMember}
         onTabChange={onTabChange}
       />
       {commonMember && (

--- a/src/pages/common/components/CommonTabs/CommonTabs.tsx
+++ b/src/pages/common/components/CommonTabs/CommonTabs.tsx
@@ -9,6 +9,7 @@ import {
   PeopleGroupIcon,
   WalletIcon,
 } from "@/shared/icons";
+import { CommonMember } from "@/shared/models";
 import { CommonTab } from "../../constants";
 import { getCommonTabName } from "../../utils";
 import styles from "./CommonTabs.module.scss";
@@ -17,6 +18,7 @@ interface CommonTabsProps {
   className?: string;
   activeTab: CommonTab;
   isAuthenticated?: boolean;
+  commonMember: CommonMember | null;
   onTabChange: (tab: CommonTab) => void;
 }
 
@@ -51,17 +53,25 @@ const TABS: { label: string; value: CommonTab; icon?: ReactNode }[] = [
 // Mobile version should display only following tabs: About, Feed and Governance
 const MOBILE_TABS = [TABS[0], TABS[1], TABS[4]];
 
-// Tabs available for unauthenticated user: about, governance
-const UNAUTHENTICATED_TABS = [TABS[0], TABS[4]];
+// Tabs available for unauthenticated or non-member users: about, governance
+const UNAUTHENTICATED_OR_NON_MEMBERS_TABS = [TABS[0], TABS[4]];
 
 const CommonTabs: FC<CommonTabsProps> = (props) => {
-  const { className, activeTab, isAuthenticated = false, onTabChange } = props;
+  const {
+    className,
+    activeTab,
+    isAuthenticated = false,
+    commonMember,
+    onTabChange,
+  } = props;
   const isTabletView = useIsTabletView();
-  const tabs = isAuthenticated
-    ? isTabletView
-      ? MOBILE_TABS
-      : TABS
-    : UNAUTHENTICATED_TABS;
+  const tabs =
+    isAuthenticated && commonMember
+      ? isTabletView
+        ? MOBILE_TABS
+        : TABS
+      : UNAUTHENTICATED_OR_NON_MEMBERS_TABS;
+
   const itemStyles = {
     "--items-amount": tabs.length,
   } as CSSProperties;


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Non-members see the same tabs as unauthenticated users: only `About` and `Governance`

### How to test?
- [ ] Go to a common when you're logged out, authenticated but not a member and authenticated and you're a member.
