### PR TITLE
Proposal Card - Result of voting - Label fix #1106

### DIFF
--- a/src/pages/OldCommon/components/ProposalContainer/CountDownCard/helpers.ts
+++ b/src/pages/OldCommon/components/ProposalContainer/CountDownCard/helpers.ts
@@ -68,3 +68,6 @@ export const checkIsFailingVoting = (votingStatus: VotingStatus): boolean =>
   [VotingStatus.Failing, VotingStatus.Rejected, VotingStatus.Canceled].includes(
     votingStatus,
   );
+
+export const checkIsVotingFinished = (votingStatus: VotingStatus): boolean =>
+  ![VotingStatus.Failing, VotingStatus.Passing].includes(votingStatus);

--- a/src/pages/common/components/ProposalFeedCard/components/ProposalFeedVotingInfo/ProposalFeedVotingInfo.tsx
+++ b/src/pages/common/components/ProposalFeedCard/components/ProposalFeedVotingInfo/ProposalFeedVotingInfo.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import {
   calculateVotingStatus,
   checkIsFailingVoting,
+  checkIsVotingFinished,
 } from "@/pages/OldCommon/components/ProposalContainer/CountDownCard/helpers";
 import { getVotersString } from "@/pages/OldCommon/containers/ProposalContainer/helpers";
 import { useCountdown } from "@/shared/hooks";
@@ -81,7 +82,9 @@ export const ProposalFeedVotingInfo: React.FC<ProposalFeedVotingInfoProps> = (
           {votersString}
         </p>
       </VotingInfo>
-      <VotingInfo label="Status">
+      <VotingInfo
+        label={checkIsVotingFinished(votingStatus) ? "Result" : "Status"}
+      >
         <ModalTriggerButton
           className={classNames(styles.votingStatus, {
             [styles.votingStatusFailing]: checkIsFailingVoting(votingStatus),


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] changed label for voting status to `Result` when voting is completed

### How to test?
- [ ] open `Feed` tab
- [ ] check proposal feed items
- [ ] if discussion/voting is in process, then you should see label `Status` for status. If voting is completed, then `Result` as label there
