### PR TITLE
Common - Show Join button for non-authenticated users #1144

### DIFF
--- a/src/pages/common/Common.tsx
+++ b/src/pages/common/Common.tsx
@@ -84,7 +84,6 @@ const Common: FC = () => {
       parentCommonSubCommons={commonData.parentCommonSubCommons}
       isGlobalDataFetched={isGlobalDataFetched}
       commonMember={commonMember}
-      isCommonMemberFetched={isCommonMemberFetched}
       isJoinPending={isJoinPending}
       setIsJoinPending={setIsJoinPending}
     />

--- a/src/pages/common/components/CommonContent/CommonContent.tsx
+++ b/src/pages/common/components/CommonContent/CommonContent.tsx
@@ -29,7 +29,6 @@ interface CommonContentProps {
   parentCommonSubCommons: Common[];
   isGlobalDataFetched: boolean;
   commonMember: (CommonMember & CirclesPermissions) | null;
-  isCommonMemberFetched: boolean;
   isJoinPending: boolean;
   setIsJoinPending: (isJoinPending: boolean) => void;
 }
@@ -42,7 +41,6 @@ const CommonContent: FC<CommonContentProps> = (props) => {
     subCommons,
     isGlobalDataFetched,
     commonMember,
-    isCommonMemberFetched,
     parentCommon,
     parentCommonSubCommons,
     isJoinPending,
@@ -72,7 +70,7 @@ const CommonContent: FC<CommonContentProps> = (props) => {
       parentCommon={parentCommon}
       governance={governance}
       commonMember={commonMember}
-      isCommonMemberFetched={isCommonMemberFetched}
+      isGlobalDataFetched={isGlobalDataFetched}
       parentCommons={parentCommons}
       subCommons={subCommons}
       parentCommonSubCommons={parentCommonSubCommons}

--- a/src/pages/common/providers/CommonData/CommonData.tsx
+++ b/src/pages/common/providers/CommonData/CommonData.tsx
@@ -30,7 +30,7 @@ interface CommonDataProps {
   common: Common;
   governance: Governance;
   commonMember: (CommonMember & CirclesPermissions) | null;
-  isCommonMemberFetched: boolean;
+  isGlobalDataFetched: boolean;
   parentCommons: Common[];
   subCommons: Common[];
   parentCommon?: Common;
@@ -44,7 +44,7 @@ const CommonData: FC<CommonDataProps> = (props) => {
     common,
     governance,
     commonMember,
-    isCommonMemberFetched,
+    isGlobalDataFetched,
     parentCommons,
     subCommons,
     parentCommon,
@@ -91,9 +91,8 @@ const CommonData: FC<CommonDataProps> = (props) => {
   const isProject = Boolean(common.directParent);
 
   const isJoinPending =
-    isCommonMemberFetched && !commonMember && props.isJoinPending;
-  const isJoinAllowed =
-    isCommonMemberFetched && !commonMember && !isJoinPending;
+    isGlobalDataFetched && !commonMember && props.isJoinPending;
+  const isJoinAllowed = isGlobalDataFetched && !commonMember && !isJoinPending;
 
   const handleMenuItemSelect = useCallback(
     (menuItem: CommonMenuItem | null) => {
@@ -121,10 +120,10 @@ const CommonData: FC<CommonDataProps> = (props) => {
   };
 
   useEffect(() => {
-    if (!isJoinAllowed && isCommonJoinModalOpen) {
+    if (isGlobalDataFetched && !isJoinAllowed && isCommonJoinModalOpen) {
       onCommonJoinModalClose();
     }
-  }, [isJoinAllowed, isCommonJoinModalOpen]);
+  }, [isGlobalDataFetched, isJoinAllowed, isCommonJoinModalOpen]);
 
   const contextValue = useMemo<CommonDataContextValue>(
     () => ({


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Join button is displayed for non-authenticated users. If pressed the login modal is displayed first.

### How to test?
1. Go to a common where you're not a member and make sure you're logged out. Try to join the common.
2. Do the same while you're logged in.
