### PR TITLE
Make the feed tab default for Members of a common\project #1175

### DIFF
--- a/src/pages/common/components/CommonContent/CommonContent.tsx
+++ b/src/pages/common/components/CommonContent/CommonContent.tsx
@@ -55,12 +55,8 @@ const CommonContent: FC<CommonContentProps> = (props) => {
   const isSubCommon = common.directParent !== null;
 
   useEffect(() => {
-    if (commonMember?.id) {
-      setTab(CommonTab.Feed);
-    } else {
-      setTab(CommonTab.About);
-    }
-  }, [commonMember]);
+    setTab(commonMember?.id ? CommonTab.Feed : CommonTab.About);
+  }, [commonMember?.id]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] The feed tab is now default for members.

### How to test?
- [ ] Go to any common while you're logged in and verify that the default tab is feed. Also while you're in a common, disconnect and connect and verify this as well.
