### PR TITLE
Feed - User profile pop-up #1146

### DIFF
--- a/src/pages/OldCommon/components/CommonDetailContainer/MembersComponent/CommonMemberPreview.tsx
+++ b/src/pages/OldCommon/components/CommonDetailContainer/MembersComponent/CommonMemberPreview.tsx
@@ -23,6 +23,7 @@ interface CommonMemberPreview {
   country?: string;
   about?: string;
   dataFetched?: boolean;
+  showCommonsOfMember?: boolean;
 }
 
 export const CommonMemberPreview: FC<CommonMemberPreview> = (props) => {
@@ -37,6 +38,7 @@ export const CommonMemberPreview: FC<CommonMemberPreview> = (props) => {
     country,
     about,
     dataFetched = true,
+    showCommonsOfMember = false,
   } = props;
   const [previewInfo, setPreviewInfo] = useState<CommonMemberPreviewInfo>(
     {} as CommonMemberPreviewInfo,
@@ -106,18 +108,22 @@ export const CommonMemberPreview: FC<CommonMemberPreview> = (props) => {
             </div>
           </>
         )}
-        <p className="common-member-preview__section-title">
-          Member of the following Commons
-        </p>
-        {commonsInfo.map((commonInfo) => (
-          <div
-            key={commonInfo.id}
-            className="common-member-preview__common-name"
-          >
-            {commonInfo.name} - {commonInfo.userCircleNames}
-            {commonInfo.id === commonId && " (current)"}
-          </div>
-        ))}
+        {showCommonsOfMember && (
+          <>
+            <p className="common-member-preview__section-title">
+              Member of the following Commons
+            </p>
+            {commonsInfo.map((commonInfo) => (
+              <div
+                key={commonInfo.id}
+                className="common-member-preview__common-name"
+              >
+                {commonInfo.name} - {commonInfo.userCircleNames}
+                {commonInfo.id === commonId && " (current)"}
+              </div>
+            ))}
+          </>
+        )}
       </>
     );
   };


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] CommonMemberPreview: add prop to show/not show other commons that the member is in.

### How to test?
- [ ] Go to any feed item and press the member to verify there is no "Member of the following Commons" section.
