### PR TITLE
Feed - Click content or footer to open chat#1168

### DIFF
--- a/src/pages/common/components/ProposalFeedCard/components/ModalTriggerButton/ModalTriggerButton.tsx
+++ b/src/pages/common/components/ProposalFeedCard/components/ModalTriggerButton/ModalTriggerButton.tsx
@@ -9,11 +9,17 @@ const ModalTriggerButton: ForwardRefRenderFunction<
   HTMLButtonElement,
   ModalTriggerButtonProps
 > = (props, ref) => {
-  const { className, children, ...restProps } = props;
+  const { className, children, onClick, ...restProps } = props;
+
+  const handleClick = (event) => {
+    event.stopPropagation();
+    onClick && onClick(event);
+  }
 
   return (
     <button
       {...restProps}
+      onClick={handleClick}
       ref={ref}
       className={classNames(styles.button, className)}
     >


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/1168

### What was changed?
- Added stopPropagation event to onClick

### How to test?
- open mobile view
- Click on voters into ProposalFeedCard
