### PR TITLE
Add a link to a (pdf) file for the governance setting for each common #1216

### DIFF
--- a/src/pages/common/components/CommonTabPanels/components/AboutTab/components/CommonGovernance/CommonGovernance.module.scss
+++ b/src/pages/common/components/CommonTabPanels/components/AboutTab/components/CommonGovernance/CommonGovernance.module.scss
@@ -5,14 +5,14 @@
   margin: 0 0 0.375rem;
   font-size: $small;
   color: $c-neutrals-600;
-  display: flex;
-  align-items: center;
 
   @include tablet {
     margin-bottom: 1rem;
   }
-  &.link {
-    cursor: pointer;
+
+  .titleLink {
+    display: flex;
+    align-items: center;
   }
 }
 

--- a/src/pages/common/components/CommonTabPanels/components/AboutTab/components/CommonGovernance/CommonGovernance.tsx
+++ b/src/pages/common/components/CommonTabPanels/components/AboutTab/components/CommonGovernance/CommonGovernance.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from "react";
-import classNames from "classnames";
 import { ViewportBreakpointVariant } from "@/shared/constants";
 import { useIsTabletView } from "@/shared/hooks/viewport";
 import NewTabIcon from "@/shared/icons/newtab.icon";
@@ -15,6 +14,7 @@ interface CommonGovernanceProps {
 const CommonGovernance: FC<CommonGovernanceProps> = (props) => {
   const { commonName, titleUrl } = props;
   const isTabletView = useIsTabletView();
+  const titleText = "Governance";
 
   return (
     <Container
@@ -25,11 +25,15 @@ const CommonGovernance: FC<CommonGovernanceProps> = (props) => {
       ]}
     >
       <CommonCard hideCardStyles={isTabletView}>
-        <h3
-          className={classNames(styles.title, { [styles.link]: titleUrl })}
-          onClick={() => titleUrl && window.open(titleUrl)}
-        >
-          Governance {titleUrl && <NewTabIcon className={styles.newTabIcon} />}
+        <h3 className={styles.title}>
+          {titleUrl ? (
+            <a href={titleUrl} target="_blank" className={styles.titleLink}>
+              {titleText}
+              <NewTabIcon className={styles.newTabIcon} />
+            </a>
+          ) : (
+            titleText
+          )}
         </h3>
         <p className={styles.description}>
           The various permissions for each circle in{" "}

--- a/src/shared/icons/newtab.icon.tsx
+++ b/src/shared/icons/newtab.icon.tsx
@@ -5,6 +5,8 @@ interface NewTabIconProps {
 }
 
 const NewTabIcon: FC<NewTabIconProps> = ({ className }) => {
+  const color = "currentColor";
+
   return (
     <svg
       className={className}
@@ -16,7 +18,7 @@ const NewTabIcon: FC<NewTabIconProps> = ({ className }) => {
     >
       <path
         d="M12.5 9.5V13.25C12.5 13.6478 12.342 14.0294 12.0607 14.3107C11.7794 14.592 11.3978 14.75 11 14.75H2.75C2.35218 14.75 1.97064 14.592 1.68934 14.3107C1.40804 14.0294 1.25 13.6478 1.25 13.25V5C1.25 4.175 1.925 3.5 2.75 3.5H6.5M10.25 1.25H14.75V5.75M6.5 9.5L14.15 1.85"
-        stroke="#001A36"
+        stroke={color}
         stroke-width="1.5"
         stroke-linecap="round"
         stroke-linejoin="round"


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Added optional `titleUrl` prop for `<CommonGovernance />`. Given a link the title is clickable and a new tab icon is displayed.

### How to test?
- [ ] Currently a mock link is required to test the functionality unless we have commons with this info.
