### PR TITLE
Discussion - Can't create private discussion when user is not in highest circle

### DIFF
--- a/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewDiscussionCreation/NewDiscussionCreation.tsx
+++ b/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewDiscussionCreation/NewDiscussionCreation.tsx
@@ -4,7 +4,6 @@ import { selectUser } from "@/pages/Auth/store/selectors";
 import { NewDiscussionCreationFormValues } from "@/shared/interfaces";
 import { CirclesPermissions, CommonMember, Governance } from "@/shared/models";
 import { parseStringToTextEditorValue } from "@/shared/ui-kit/TextEditor";
-import { addCirclesWithHigherTier } from "@/shared/utils";
 import {
   selectDiscussionCreationData,
   selectIsDiscussionCreationLoading,
@@ -62,13 +61,7 @@ const NewDiscussionCreation: FC<NewDiscussionCreationProps> = (props) => {
         return;
       }
 
-      const circleVisibility = values.circle
-        ? addCirclesWithHigherTier(
-            [values.circle],
-            Object.values(governanceCircles),
-            userCircleIds,
-          ).map((circle) => circle.id)
-        : [];
+      const circleVisibility = values.circle ? [values.circle.id] : [];
 
       dispatch(
         commonActions.createDiscussion.request({


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] removed adding of higher circles to circle visibility (based on discussion in the issue)

### How to test?
- [ ] go to a common where you are Leader and with another account with lower circle
- [ ] try to create discussions public and private to different circles and see that discussion is created correctly, it is private to the selected circle and users with lower circles do not see discussions for higher circles
