### PR TITLE
messages actions menu fixes#1232

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.tsx
+++ b/src/pages/common/components/ChatComponent/ChatComponent.tsx
@@ -325,6 +325,7 @@ export default function ChatComponent({
             messages={messages}
             dateList={dateList}
             lastSeenItem={lastSeenItem}
+            hasPermissionToHide={hasPermissionToHide}
           />
         ) : (
           <div className="loader-container">

--- a/src/pages/common/components/ChatComponent/components/ChatContent/ChatContent.tsx
+++ b/src/pages/common/components/ChatComponent/components/ChatContent/ChatContent.tsx
@@ -32,6 +32,7 @@ interface ChatContentInterface {
   messages: Record<number, DiscussionMessage[]>;
   dateList: string[];
   lastSeenItem?: CommonFeedObjectUserUnique["lastSeen"];
+  hasPermissionToHide: boolean;
 }
 
 const isToday = (someDate: Date) => {
@@ -58,6 +59,7 @@ export default function ChatContent({
   messages,
   dateList,
   lastSeenItem,
+  hasPermissionToHide,
 }: ChatContentInterface) {
   const user = useSelector(selectUser());
 
@@ -163,6 +165,7 @@ export default function ChatContent({
                     chatType={type}
                     scrollToRepliedMessage={scrollToRepliedMessage}
                     highlighted={message.id === highlightedMessageId}
+                    hasPermissionToHide={hasPermissionToHide}
                     onMessageDropdownOpen={
                       messageIndex === messages[Number(day)].length - 1
                         ? () => {

--- a/src/shared/components/Chat/ChatMessage/ChatMessage.tsx
+++ b/src/shared/components/Chat/ChatMessage/ChatMessage.tsx
@@ -23,6 +23,7 @@ interface ChatMessageProps {
   onMessageDropdownOpen?: (isOpen: boolean) => void;
   user: User | null;
   scrollToRepliedMessage: (messageId: string) => void;
+  hasPermissionToHide: boolean;
 }
 
 const getDynamicLinkByChatType = (chatType: ChatType): DynamicLinkType => {
@@ -42,6 +43,7 @@ export default function ChatMessage({
   onMessageDropdownOpen,
   user,
   scrollToRepliedMessage,
+  hasPermissionToHide,
 }: ChatMessageProps) {
   const [isEditMode, setEditMode] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -74,7 +76,12 @@ export default function ChatMessage({
   };
 
   const ReplyMessage = useCallback(() => {
-    if (!discussionMessage.parentMessage?.id) {
+    if (
+      !discussionMessage.parentMessage?.id ||
+      (discussionMessage.parentMessage?.moderation?.flag ===
+        ModerationFlags.Hidden &&
+        !hasPermissionToHide)
+    ) {
       return null;
     }
 
@@ -98,7 +105,7 @@ export default function ChatMessage({
         </div>
       </div>
     );
-  }, [discussionMessage.parentMessage]);
+  }, [discussionMessage.parentMessage, hasPermissionToHide]);
 
   return (
     <li

--- a/src/shared/components/ElementDropdown/ElementDropdown.tsx
+++ b/src/shared/components/ElementDropdown/ElementDropdown.tsx
@@ -17,6 +17,7 @@ import {
   MenuItem as DesktopStyleMenuItem,
   MenuItemType,
 } from "@/shared/interfaces";
+import { ModerationFlags } from "@/shared/interfaces/Moderation";
 import {
   Common,
   Proposal,
@@ -105,6 +106,9 @@ const ElementDropdown: FC<ElementDropdownProps> = ({
   } = useModal(false);
   const isMobileView = screenSize === ScreenSize.Mobile;
   const isControlledMenu = typeof isOpen === "boolean";
+  const isHiddenElement =
+    (elem as DiscussionMessage | Discussion | Proposal)?.moderation?.flag ===
+    ModerationFlags.Hidden;
 
   const onReply = useCallback(() => {
     dispatch(setCurrentDiscussionMessageReply(elem as DiscussionMessage));
@@ -115,7 +119,7 @@ const ElementDropdown: FC<ElementDropdownProps> = ({
 
     const items: DropdownOption[] = [];
 
-    if (isDiscussionMessage) {
+    if (isDiscussionMessage && !isHiddenElement) {
       items.push({
         text: <span>Reply</span>,
         searchText: "Reply",
@@ -159,7 +163,8 @@ const ElementDropdown: FC<ElementDropdownProps> = ({
         governance,
         key: HideContentTypes[entityType],
       }) &&
-      !isOwner
+      !isOwner &&
+      !isHiddenElement
     ) {
       items.push({
         text: (
@@ -189,6 +194,7 @@ const ElementDropdown: FC<ElementDropdownProps> = ({
     ownerId,
     commonMember,
     governance,
+    isHiddenElement,
   ]);
 
   const handleMenuToggle = useCallback(

--- a/src/shared/components/HideModal/HideModal.tsx
+++ b/src/shared/components/HideModal/HideModal.tsx
@@ -127,7 +127,7 @@ const HideModal: FC<PropsWithChildren<HideModalProps>> = (props) => {
         content: "hide-modal__content",
       }}
     >
-      <p className="hide-modal__title">This action can be reverted</p>
+      <p className="hide-modal__title">This action cannot be reverted</p>
       <div className="hide-modal__button-container">
         <Button
           disabled={isLoading}

--- a/src/shared/hooks/useCases/useDiscussionMessagesById.ts
+++ b/src/shared/hooks/useCases/useDiscussionMessagesById.ts
@@ -93,6 +93,7 @@ export const useDiscussionMessagesById = ({
               id: parentMessage.id,
               text: parentMessage.text,
               ownerName: parentMessage?.ownerName,
+              moderation: parentMessage?.moderation,
             }
           : null;
         return newDiscussionMessage;

--- a/src/shared/models/DiscussionMessage.tsx
+++ b/src/shared/models/DiscussionMessage.tsx
@@ -22,6 +22,7 @@ export interface ParentDiscussionMessage {
   id: string;
   ownerName: string;
   text: string;
+  moderation?: Moderation;
 }
 
 export interface DiscussionMessage extends BaseEntity {


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/1232

### What was changed?
- Fixed Hidden Replied messages
- Fixed Text for hide modal
- Fixed element dropdown options

### How to test?
- Check hidden replied messages if you don't have permissions replied message should not be displayed
- If element is hidden "Reply/Hide options should not be displayed"
- Check Hide modal text "This action cannot be reverted"
