### PR TITLE
Mobile vote confirmation popup clicks behaviour #1280

### DIFF
--- a/src/shared/components/Modal/Modal.tsx
+++ b/src/shared/components/Modal/Modal.tsx
@@ -61,13 +61,18 @@ const Modal: ForwardRefRenderFunction<ModalRef, ModalProps> = (
     event.stopPropagation();
   };
 
-  const handleClose = useCallback(() => {
-    if (closePrompt) {
-      setShowClosePrompt(true);
-    } else {
-      onClose();
-    }
-  }, [closePrompt, onClose]);
+  const handleClose = useCallback<MouseEventHandler>(
+    (event) => {
+      event.stopPropagation();
+
+      if (closePrompt) {
+        setShowClosePrompt(true);
+      } else {
+        onClose();
+      }
+    },
+    [closePrompt, onClose],
+  );
 
   const handleClosePromptContinue = useCallback(() => {
     setShowClosePrompt(false);


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] added stop propagation to modal close handler

### How to test?
- [ ] open vote modal
- [ ] close it by clicking on overlay above the feed card and see that chat is not open
