### PR TITLE
Show my pending messages only in the relevant chat #1290

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.tsx
+++ b/src/pages/common/components/ChatComponent/ChatComponent.tsx
@@ -55,6 +55,7 @@ interface ChatComponentInterface {
   type: ChatType;
   commonMember: CommonMember | null;
   isCommonMemberFetched: boolean;
+  feedItemId: string;
   isJoiningPending?: boolean;
   isAuthorized?: boolean;
   highlightedMessageId?: string | null;
@@ -62,7 +63,6 @@ interface ChatComponentInterface {
   isHidden: boolean;
   proposal?: Proposal;
   discussion: Discussion;
-  feedItemId?: string;
   titleHeight?: number;
   lastSeenItem?: CommonFeedObjectUserUnique["lastSeen"];
 }
@@ -204,6 +204,7 @@ export default function ChatComponent({
           id: pendingMessageId,
           text: payload.text,
           status: PendingMessageStatus.Sending,
+          feedItemId: feedItemId,
         },
       ]);
 
@@ -370,6 +371,7 @@ export default function ChatComponent({
             hasPermissionToHide={hasPermissionToHide}
             pendingMessages={pendingMessages}
             prevPendingMessages={prevPendingMessages}
+            feedItemId={feedItemId}
           />
         ) : (
           <div className="loader-container">

--- a/src/pages/common/components/ChatComponent/components/ChatContent/ChatContent.tsx
+++ b/src/pages/common/components/ChatComponent/components/ChatContent/ChatContent.tsx
@@ -31,6 +31,7 @@ interface ChatContentInterface {
   hasPermissionToHide: boolean;
   pendingMessages: PendingMessage[];
   prevPendingMessages?: PendingMessage[];
+  feedItemId: string;
 }
 
 const isToday = (someDate: Date) => {
@@ -57,6 +58,7 @@ export default function ChatContent({
   hasPermissionToHide,
   pendingMessages,
   prevPendingMessages,
+  feedItemId,
 }: ChatContentInterface) {
   const user = useSelector(selectUser());
 
@@ -194,9 +196,11 @@ export default function ChatContent({
       })}
       {pendingMessages.length > 0 && (
         <div className={styles.pendingMessagesList}>
-          {pendingMessages.map((msg) => (
-            <PendingChatMessage key={msg.id} data={msg} />
-          ))}
+          {pendingMessages
+            .filter((msg) => msg.feedItemId === feedItemId)
+            .map((msg) => (
+              <PendingChatMessage key={msg.id} data={msg} />
+            ))}
         </div>
       )}
       {!dateList.length && !pendingMessages.length && (

--- a/src/shared/models/DiscussionMessage.tsx
+++ b/src/shared/models/DiscussionMessage.tsx
@@ -51,4 +51,5 @@ export interface PendingMessage {
   id: string;
   text: string;
   status: PendingMessageStatus;
+  feedItemId: string;
 }


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Pending messages are now shown only in their relevant chat.

### How to test?
- [ ] Send a message and quickly change a chat to see the effect. You can make a fake slow network in the development console under network tab. 
