### PR TITLE
Increase width of chat message dropdown

### DIFF
--- a/src/shared/components/ElementDropdown/ElementDropdown.module.scss
+++ b/src/shared/components/ElementDropdown/ElementDropdown.module.scss
@@ -5,8 +5,7 @@
   left: 50%;
   right: unset;
   z-index: 1;
-  max-width: 13.75rem;
-  width: 100%;
+  min-width: 13.75rem;
   transform: translateX(-50%);
 }
 


### PR DESCRIPTION
One of the fixes for https://github.com/daostack/common-web/pull/1261.

By not making it full width, it will not be slim for short messages
