### PR TITLE
Proposal card - Hide "my vote is" for null outcome #1306

### DIFF
--- a/src/pages/common/components/ProposalFeedCard/components/UserVoteInfo/UserVoteInfo.tsx
+++ b/src/pages/common/components/ProposalFeedCard/components/UserVoteInfo/UserVoteInfo.tsx
@@ -36,7 +36,7 @@ export const UserVoteInfo: FC<UserVoteInfoProps> = (props) => {
     [styles.containerReject]: userVote?.outcome === VoteOutcome.Rejected,
   });
 
-  if (!userVote) {
+  if (!userVote?.outcome) {
     return userHasPermissionsToVote && !isCountdownState ? (
       <div className={styles.container}>You didn’t vote to this proposal</div>
     ) : null;


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/1306

### What was changed?
- Added check for vote outcome

### How to test?
- Create Proposal
- If you don't vote -> `My vote is block` must be hidden
