### PR TITLE
Use new sidebar with the Profile page #1350

### DIFF
--- a/src/pages/App/router/configuration/commonSidenavLayout.tsx
+++ b/src/pages/App/router/configuration/commonSidenavLayout.tsx
@@ -1,6 +1,8 @@
+import { BillingPage } from "@/pages/billing";
 import { CommonCreationPage } from "@/pages/commonCreation";
 import { CommonFeedPage } from "@/pages/commonFeed";
 import { InboxPage } from "@/pages/inbox";
+import { ProfilePage } from "@/pages/profile";
 import { ROUTE_PATHS } from "@/shared/constants";
 import { CommonSidenavLayout } from "@/shared/layouts";
 import { LayoutConfiguration } from "../types";
@@ -27,6 +29,16 @@ export const COMMON_SIDENAV_LAYOUT_CONFIGURATION: LayoutConfiguration<CommonSide
         path: ROUTE_PATHS.PROJECT_CREATION,
         exact: true,
         component: CommonCreationPage,
+      },
+      {
+        path: ROUTE_PATHS.PROFILE,
+        exact: true,
+        component: ProfilePage,
+      },
+      {
+        path: ROUTE_PATHS.BILLING,
+        exact: true,
+        component: BillingPage,
       },
     ],
   };

--- a/src/pages/App/router/configuration/sidenavLayout.tsx
+++ b/src/pages/App/router/configuration/sidenavLayout.tsx
@@ -1,7 +1,5 @@
-import { BillingPage } from "@/pages/billing";
 import CommonPage from "@/pages/common/Common";
 import { CommonEditingPage } from "@/pages/commonEditing";
-import { ProfilePage } from "@/pages/profile";
 import { ROUTE_PATHS } from "@/shared/constants";
 import { SidenavLayout } from "@/shared/layouts";
 import { ALL_COMMON_PAGE_TABS } from "../../../common";
@@ -28,16 +26,6 @@ export const SIDENAV_LAYOUT_CONFIGURATION: LayoutConfiguration<SidenavLayoutRout
         path: ROUTE_PATHS.COMMON_EDITING,
         exact: true,
         component: CommonEditingPage,
-      },
-      {
-        path: ROUTE_PATHS.PROFILE,
-        exact: true,
-        component: ProfilePage,
-      },
-      {
-        path: ROUTE_PATHS.BILLING,
-        exact: true,
-        component: BillingPage,
       },
     ],
   };

--- a/src/shared/layouts/CommonSidenavLayout/components/LayoutTabs/LayoutTabs.tsx
+++ b/src/shared/layouts/CommonSidenavLayout/components/LayoutTabs/LayoutTabs.tsx
@@ -3,7 +3,11 @@ import { useHistory } from "react-router-dom";
 import classNames from "classnames";
 import { Tab, Tabs } from "@/shared/components";
 import { Avatar2Icon, InboxIcon, Hamburger2Icon } from "@/shared/icons";
-import { getInboxPagePath, openSidenav } from "@/shared/utils";
+import {
+  getInboxPagePath,
+  getProfilePagePath,
+  openSidenav,
+} from "@/shared/utils";
 import { LayoutTab } from "../../constants";
 import { getActiveLayoutTab, getLayoutTabName } from "./utils";
 import styles from "./LayoutTabs.module.scss";
@@ -58,8 +62,10 @@ const LayoutTabs: FC<LayoutTabsProps> = (props) => {
         openSidenav();
         break;
       case LayoutTab.Inbox:
-      case LayoutTab.Profile:
         history.push(getInboxPagePath());
+        break;
+      case LayoutTab.Profile:
+        history.push(getProfilePagePath());
         break;
       default:
         break;

--- a/src/shared/utils/routes.ts
+++ b/src/shared/utils/routes.ts
@@ -23,3 +23,5 @@ export const getCommonSupportPagePath = (commonId: string): string =>
   ROUTE_PATHS.COMMON_SUPPORT.replace(":id", commonId);
 
 export const getInboxPagePath = (): string => ROUTE_PATHS.INBOX;
+
+export const getProfilePagePath = (): string => ROUTE_PATHS.PROFILE;


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] moved Profile and Billing pages to common sidenav layout
- [x] changed Profile layout tab to lead to Profile page

### How to test?
- [ ] open new ui and try to go to profile and billing pages and see that they are displayed with the new layout
