### PR TITLE
Profile popup - wrong intro is displayed #1342

### DIFF
--- a/src/shared/hooks/useCases/useCommonMemberWithUserInfo.ts
+++ b/src/shared/hooks/useCases/useCommonMemberWithUserInfo.ts
@@ -53,7 +53,7 @@ export const useCommonMemberWithUserInfo = (
     ? {
         data: {
           id: commonMember.id,
-          userId: commonMember.userId,
+          userId: user.uid,
           joinedAt: commonMember.joinedAt,
           circleIds: [circlesString],
           user: user,

--- a/src/shared/models/User.tsx
+++ b/src/shared/models/User.tsx
@@ -17,7 +17,7 @@ export interface User {
   createdAt?: Date;
   updatedAt?: Date;
   proposals?: Proposal[];
-  uid?: string;
+  uid: string;
   roles?: UserRole[];
   deleted?: true;
   //  subscriptions?: Subscription[];


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Fix: wrong member intro while pressing members from the feed.

### How to test?
- [ ] Press any member avatar from the feed and make sure the intro is unique.
