### PR TITLE
Fast switching between commons and spaces crashes the app #1423

### DIFF
--- a/src/pages/commonFeed/CommonFeed.tsx
+++ b/src/pages/commonFeed/CommonFeed.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router";
-import { useParams } from "react-router-dom";
 import { selectUser } from "@/pages/Auth/store/selectors";
 import { CommonAction, QueryParamKey } from "@/shared/constants";
 import { useQueryParams } from "@/shared/hooks";
@@ -23,12 +22,12 @@ import { FeedLayout, FeedLayoutRef, HeaderContent } from "./components";
 import { useCommonData, useGlobalCommonData } from "./hooks";
 import styles from "./CommonFeed.module.scss";
 
-interface CommonFeedPageRouterParams {
-  id: string;
+interface CommonFeedProps {
+  commonId: string;
 }
 
-const CommonFeedPage: FC = () => {
-  const { id: commonId } = useParams<CommonFeedPageRouterParams>();
+const CommonFeed: FC<CommonFeedProps> = (props) => {
+  const { commonId } = props;
   const queryParams = useQueryParams();
   const dispatch = useDispatch();
   const history = useHistory();
@@ -199,4 +198,4 @@ const CommonFeedPage: FC = () => {
   );
 };
 
-export default CommonFeedPage;
+export default CommonFeed;

--- a/src/pages/commonFeed/CommonFeedPage.tsx
+++ b/src/pages/commonFeed/CommonFeedPage.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from "react";
+import { useParams } from "react-router-dom";
+import CommonFeed from "./CommonFeed";
+
+interface CommonFeedPageRouterParams {
+  id: string;
+}
+
+const CommonFeedPage: FC = () => {
+  const { id: commonId } = useParams<CommonFeedPageRouterParams>();
+
+  return <CommonFeed key={commonId} commonId={commonId} />;
+};
+
+export default CommonFeedPage;

--- a/src/pages/commonFeed/index.ts
+++ b/src/pages/commonFeed/index.ts
@@ -1,1 +1,1 @@
-export { default as CommonFeedPage } from "./CommonFeed";
+export { default as CommonFeedPage } from "./CommonFeedPage";


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] created a wrapper about existing common feed page, which renders `CommonFeed` with `commonId` as key, so that on each common id change (like going to another common/project) the page will be fully re-rendered and we will not have issues with stale data, which cased page crashes due to data inconsistency

### How to test?
- [ ] open common feed page and try switching fast between the commons and spaces. See that the app doesn't crash and the data is displayed correctly
