### PR TITLE
Some UI components appear wrong after recent pushes #1427

### DIFF
--- a/src/shared/layouts/CommonSidenavLayout/components/PageContent/PageContent.module.scss
+++ b/src/shared/layouts/CommonSidenavLayout/components/PageContent/PageContent.module.scss
@@ -19,10 +19,10 @@
   }
 }
 .containerWithHeader {
-  --header-h: $container-desktop-header-height;
+  --header-h: #{$container-desktop-header-height};
 
   @include tablet {
-    --header-h: $container-mobile-header-height;
+    --header-h: #{$container-mobile-header-height};
   }
 }
 


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fixed header height variable set up

### How to test?
- [x] open common feed and see that header has correct size and the header is not above the items by default
