### PR TITLE
Missing required label in space creation

### DIFF
--- a/src/pages/commonCreation/components/ProjectCreation/components/ProjectCreationForm/configuration.ts
+++ b/src/pages/commonCreation/components/ProjectCreation/components/ProjectCreationForm/configuration.ts
@@ -15,7 +15,7 @@ export const getConfiguration = (isProject = true): CreationFormItem[] => {
       className: styles.projectImages,
       props: {
         name: "projectImages",
-        label: `${type} picture`,
+        label: `${type} picture ${isProject && "(required)"}`,
         maxImagesAmount: 1,
       },
       validation: {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Fix: missing required label in space creation

### How to test?
- [ ] Go to create space section and see the label.
