### PR TITLE
Mobile: 'new' and 'proposal' tags are cut #1458

### DIFF
--- a/src/pages/common/components/FeedCard/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
+++ b/src/pages/common/components/FeedCard/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
@@ -63,6 +63,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  overflow: hidden;
 }
 
 .topContent {
@@ -82,9 +83,6 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  @include big-phone {
-    justify-content: unset;
-  }
 }
 
 .text {
@@ -117,10 +115,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-
-  @include big-phone {
-    max-width: 40%;
-  }
 }
 
 .lastMessageActive {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] On mobile view, that 'proposal' and 'new' tags are not cut. 

### How to test?
- [ ] Check on mobile view.
