### PR TITLE
Hide invite friends button for non-members #1441

### DIFF
--- a/src/pages/common/components/CommonTabPanels/components/AboutTab/utils/getAllowedActions.ts
+++ b/src/pages/common/components/CommonTabPanels/components/AboutTab/utils/getAllowedActions.ts
@@ -11,7 +11,9 @@ export const getAllowedActions = (
     ? [AboutAction.Edit]
     : [];
 
-  allowedActions.push(AboutAction.InviteFriends);
+  if (commonMember) {
+    allowedActions.push(AboutAction.InviteFriends);
+  }
 
   return allowedActions;
 };


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] hid `Invite friends` button from non-members of common

### How to test?
- [ ] open a common/space where you are a member - you should see button to invite friends in `About` tab
- [ ] open a common/space where you are not a member - you should see that button
