### PR TITLE
Inbox - for the last message preview, cut the text for long messages #1500

### DIFF
--- a/src/pages/inbox/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
+++ b/src/pages/inbox/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
@@ -84,6 +84,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  overflow: hidden;
 }
 
 .topContent {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] added `overflow: hidden` to the content of inbox item preview. That is a bit strange, why it doesn't work without it, because for feed item preview the styles are same and everything is fine there with 3 dots

### How to test?
- [ ] open inbox page, where you have an item with long last message and see that 3 dots are correctly displayed
