### PR TITLE
Change Feed items see more behaviour #1443

### DIFF
--- a/src/pages/common/components/FeedCard/components/FeedGeneralInfo/FeedGeneralInfo.module.scss
+++ b/src/pages/common/components/FeedCard/components/FeedGeneralInfo/FeedGeneralInfo.module.scss
@@ -57,10 +57,3 @@
 .image {
   max-width: 33.0625rem;
 }
-
-.attachIcon {
-  flex-shrink: 0;
-  width: 0.875rem;
-  height: 0.9375rem;
-  margin-left: 0.75rem;
-}

--- a/src/pages/common/components/FeedCard/components/FeedGeneralInfo/FeedGeneralInfo.tsx
+++ b/src/pages/common/components/FeedCard/components/FeedGeneralInfo/FeedGeneralInfo.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useMemo } from "react";
 import classNames from "classnames";
 import { useFullText } from "@/shared/hooks";
-import { AttachIcon } from "@/shared/icons";
 import { CommonLink } from "@/shared/models";
 import {
   checkIsTextEditorValueEmpty,
@@ -31,8 +30,7 @@ export const FeedGeneralInfo: React.FC<FeedGeneralInfoProps> = (props) => {
   );
   const isDescriptionEmpty = checkIsTextEditorValueEmpty(parsedDescription);
   const shouldDisplaySeeMoreButton =
-    ((shouldShowFullContent || !isFullTextShowing) && !isDescriptionEmpty) ||
-    images.length > 0;
+    (shouldShowFullContent || !isFullTextShowing) && !isDescriptionEmpty;
 
   const handleSeeMoreClick = (event) => {
     event.stopPropagation();
@@ -54,27 +52,15 @@ export const FeedGeneralInfo: React.FC<FeedGeneralInfoProps> = (props) => {
           readOnly
         />
       )}
-      {images.length > 0 && shouldShowFullContent && (
-        <ImageGallery gallery={images} />
-      )}
       {shouldDisplaySeeMoreButton && (
         <a
           className={classNames(styles.seeMore, styles.text)}
           onClick={handleSeeMoreClick}
         >
-          See{" "}
-          {shouldShowFullContent ? (
-            "less"
-          ) : (
-            <>
-              more
-              {images.length > 0 && (
-                <AttachIcon className={styles.attachIcon} />
-              )}
-            </>
-          )}
+          See {shouldShowFullContent ? "less" : "more"}
         </a>
       )}
+      {images.length > 0 && <ImageGallery gallery={images} />}
     </div>
   );
 };


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] change non-shortened lines amount to `7`
- [x] removed images from the "see more" content, so they are always visible to user

### How to test?
- [ ] open feed/inbox, open different items, where there is a lot of text (more than 7 lines), where there are images, or where there are both long text and images and see that it works as described in the ticket
