### PR TITLE
Assign Circle proposal: update visibility string #1529

### DIFF
--- a/src/pages/common/components/FeedCard/utils/getVisibilityString.ts
+++ b/src/pages/common/components/FeedCard/utils/getVisibilityString.ts
@@ -22,5 +22,10 @@ export const getVisibilityString = (
   const memberSpecific =
     proposalType === ProposalsTypes.ASSIGN_CIRCLE ? `, ${memberName}` : "";
 
-  return circleNames ? `Private, ${circleNames} ${memberSpecific}` : "Public";
+  /**
+   * Temporary hide memberSpecific. See https://github.com/daostack/common-web/issues/1529
+   */
+  //return circleNames ? `Private, ${circleNames} ${memberSpecific}` : "Public";
+
+  return circleNames ? `Private, ${circleNames}` : "Public";
 };


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Assign circle: temporary hide member name from visibility string.

### How to test?
- [ ] Ask to join to a circle. Use another member with higher circle to see that the visibility string doesn't contain the proper name.
