### PR TITLE
common\space creation-when open link in the mail i receive, general channel appears twice #1513

### DIFF
--- a/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
@@ -63,7 +63,6 @@ interface FeedLayoutProps {
   common?: Common;
   governance?: Governance;
   commonMember: (CommonMember & CirclesPermissions) | null;
-  pinnedFeedItems?: FeedLayoutItem[] | null;
   feedItems: FeedLayoutItem[] | null;
   topFeedItems?: FeedLayoutItem[];
   loading: boolean;
@@ -87,7 +86,6 @@ const FeedLayout: ForwardRefRenderFunction<FeedLayoutRef, FeedLayoutProps> = (
     common: outerCommon,
     governance: outerGovernance,
     commonMember: outerCommonMember,
-    pinnedFeedItems,
     feedItems,
     topFeedItems = [],
     loading,
@@ -126,10 +124,6 @@ const FeedLayout: ForwardRefRenderFunction<FeedLayoutRef, FeedLayoutProps> = (
   const allFeedItems = useMemo(() => {
     const items: FeedLayoutItem[] = [];
 
-    if (pinnedFeedItems) {
-      items.push(...pinnedFeedItems);
-    }
-
     if (topFeedItems) {
       items.push(...topFeedItems);
     }
@@ -138,7 +132,7 @@ const FeedLayout: ForwardRefRenderFunction<FeedLayoutRef, FeedLayoutProps> = (
     }
 
     return items;
-  }, [topFeedItems, feedItems, pinnedFeedItems]);
+  }, [topFeedItems, feedItems]);
 
   const feedItemIdForAutoChatOpen = useMemo(() => {
     if (recentStreamId) {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] removed `pinnedFeedItems` prop from `FeedLayout`
- [x] moved pinned items to the `topFeedItems` of common feed and filter shared feed item there from the pinned items array

### How to test?
- [ ] go to a common where an item is pinned
- [ ] check the `id` of that item and add it as a query param to the url (`?item={item id}`)
- [ ] after the page is loaded see that the item is on top and is not duplicated as pinned item, because it is "shared" now
