### PR TITLE
Missing required label in discussion and proposal creation #1510

### DIFF
--- a/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewDiscussionCreation/components/DiscussionForm/DiscussionForm.tsx
+++ b/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewDiscussionCreation/components/DiscussionForm/DiscussionForm.tsx
@@ -22,7 +22,7 @@ const DiscussionForm: FC<DiscussionFormProps> = (props) => {
         className={styles.field}
         id="discussionTitle"
         name="title"
-        label="Discussion Title"
+        label="Discussion Title (required)"
         maxLength={MAX_DISCUSSION_TITLE_LENGTH}
         countAsHint
         disabled={disabled}

--- a/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewProposalCreation/components/ProposalForm/ProposalForm.tsx
+++ b/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewProposalCreation/components/ProposalForm/ProposalForm.tsx
@@ -43,7 +43,7 @@ const ProposalForm: FC<ProposalFormProps> = (props) => {
         className={styles.field}
         id="proposalTitle"
         name="title"
-        label="Proposal Title"
+        label="Proposal Title (required)"
         maxLength={MAX_PROPOSAL_TITLE_LENGTH}
         countAsHint
         disabled={disabled}


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Added missing _required_ label in discussion and proposal creation form.

### How to test?
- [ ] Go to create discussion/proposal forms and see.
