### PR TITLE
Inbox - for the last message preview, cut the text for long messages - Fix #1500

### DIFF
--- a/src/pages/common/components/FeedCard/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
+++ b/src/pages/common/components/FeedCard/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
@@ -126,9 +126,11 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+
   & > p {
-    overflow: hidden;
+    white-space: nowrap;
     text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   @include tablet {

--- a/src/pages/inbox/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
+++ b/src/pages/inbox/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
@@ -144,6 +144,12 @@
   white-space: nowrap;
   overflow: hidden;
 
+  & > p {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
   @include tablet {
     max-width: 16.1875rem;
   }


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] added same style to inbox related feed item base content `p` inside the `TextEditor` as we have on feed page
