### PR TITLE
PROD - when share a channel - the created link is wrong #1597

### DIFF
--- a/src/shared/utils/generateStaticShareLink.ts
+++ b/src/shared/utils/generateStaticShareLink.ts
@@ -11,7 +11,7 @@ const staticLinkPrefix = () => {
     case Environment.Stage:
       return "https://web-staging.common.io";
     case Environment.Production:
-      return "https://app.common.io";
+      return "https://common.io";
   }
 };
 


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fixed static link prefix for production
