### PR TITLE
Chat: can't press send when the message begins with a mention #1624

### DIFF
--- a/src/shared/ui-kit/TextEditor/utils/checkIsTextEditorValueEmpty.ts
+++ b/src/shared/ui-kit/TextEditor/utils/checkIsTextEditorValueEmpty.ts
@@ -1,5 +1,6 @@
 import { Element, Text } from "slate";
-import { MentionElement, TextEditorValue } from "../types";
+import { ElementType } from "../constants";
+import { TextEditorValue } from "../types";
 
 export const checkIsTextEditorValueEmpty = (
   value: TextEditorValue,
@@ -18,10 +19,10 @@ export const checkIsTextEditorValueEmpty = (
   }
 
   const firstChild = firstElement.children[0];
-  const secondChild = firstElement.children[1] as MentionElement;
+  const secondChild = firstElement.children[1];
 
-  if (secondChild) {
-    return secondChild.displayName === "";
+  if (Element.isElementType(secondChild, ElementType.Mention)) {
+    return false;
   }
 
   if (!Text.isText(firstChild)) {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Chat fix: can't press send when a message begins with a mention. `checkIsTextEditorValueEmpty` checks also for mention objects now.
