### PR TITLE
Reply message appears in other chats #1593

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.tsx
+++ b/src/pages/common/components/ChatComponent/ChatComponent.tsx
@@ -200,6 +200,7 @@ export default function ChatComponent({
   useEffect(() => {
     if (discussionId) {
       fetchDiscussionMessages(discussionId);
+      dispatch(chatActions.clearCurrentDiscussionMessageReply());
     }
   }, [discussionId]);
 

--- a/src/pages/common/components/ChatComponent/components/MessageReply/MessageReply.module.scss
+++ b/src/pages/common/components/ChatComponent/components/MessageReply/MessageReply.module.scss
@@ -3,10 +3,8 @@
 .container {
   display: flex;
   flex-direction: row;
-  width: calc(100% - 2rem);
   background-color: $white;
   padding: 0.4375rem 2rem 0.625rem;
-  margin-bottom: 0.125rem;
   border-top: 0.0625rem solid $c-neutrals-100;
   border-bottom: 0.0625rem solid $c-neutrals-100;
 }


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Reply message: clear on chat change ; fix bad styles causing overflow for the reply message container (see image).

<img width="308" alt="Screen Shot 2023-06-04 at 17 28 52" src="https://github.com/daostack/common-web/assets/34843014/e1b5d315-fd64-45cd-ae6f-18fa4eab7ea0">
