### PR TITLE
Make New discussion to be above New proposal in the New stream dropdown #1653

### DIFF
--- a/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewStreamButton/hooks/useMenuItems.ts
+++ b/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewStreamButton/hooks/useMenuItems.ts
@@ -18,17 +18,17 @@ export const useMenuItems = (options: Options): Item[] => {
 
   const items: Item[] = [
     {
-      id: CommonAction.NewProposal,
-      text: "New Proposal",
-      onClick: () => {
-        setMenuItem(CommonAction.NewProposal);
-      },
-    },
-    {
       id: CommonAction.NewDiscussion,
       text: "New Discussion",
       onClick: () => {
         setMenuItem(CommonAction.NewDiscussion);
+      },
+    },
+    {
+      id: CommonAction.NewProposal,
+      text: "New Proposal",
+      onClick: () => {
+        setMenuItem(CommonAction.NewProposal);
       },
     },
     {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] New stream button dropdown: new discussion appears above new proposal now.
