### PR TITLE
Link doesn’t add to a chat messsage #1628

### DIFF
--- a/src/shared/components/Chat/ChatMessage/util.tsx
+++ b/src/shared/components/Chat/ChatMessage/util.tsx
@@ -24,6 +24,7 @@ const getTextFromDescendant = (
 
   switch (descendant.type) {
     case ElementType.Paragraph:
+    case ElementType.Link:
       return (
         <span>
           {descendant.children.map((item, index) => (


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/1628

### What was changed?
- Added Link type to parser util