### PR TITLE
Add outcome unit to circle definition

### DIFF
--- a/src/shared/constants/index.tsx
+++ b/src/shared/constants/index.tsx
@@ -17,6 +17,7 @@ export * from "./language";
 export * from "./lastSeenEntity";
 export * from "./Math";
 export * from "./pinOrUnpinEndpointAction";
+export * from "./proposalOutcomeUnit";
 export * from "./queryParamKey";
 export * from "./routePaths";
 export * from "./shared";

--- a/src/shared/constants/proposalOutcomeUnit.ts
+++ b/src/shared/constants/proposalOutcomeUnit.ts
@@ -1,0 +1,4 @@
+export enum ProposalOutcomeUnit {
+  Percent = "percent",
+  Absolute = "absolute",
+}

--- a/src/shared/utils/getProjectCircleDefinition.ts
+++ b/src/shared/utils/getProjectCircleDefinition.ts
@@ -1,3 +1,5 @@
+import { ProposalOutcomeUnit } from "@/shared/constants";
+
 export const getProjectCircleDefinition = (
   name: string,
   highestCircleId: string,
@@ -10,9 +12,9 @@ export const getProjectCircleDefinition = (
       quorum: 0,
       weights: [{ circles: [highestCircleId], value: 100 }],
       minApprove: 0,
-      minApproveUnit: "percent",
+      minApproveUnit: ProposalOutcomeUnit.Percent,
       maxReject: 67,
-      maxRejectUnit: "percent",
+      maxRejectUnit: ProposalOutcomeUnit.Percent,
       votingDuration: 0,
       discussionDuration: 0,
     },
@@ -24,9 +26,9 @@ export const getProjectCircleDefinition = (
       quorum: 25,
       weights: [{ circles: [highestCircleId], value: 100 }],
       minApprove: 50,
-      minApproveUnit: "percent",
+      minApproveUnit: ProposalOutcomeUnit.Percent,
       maxReject: 50,
-      maxRejectUnit: "percent",
+      maxRejectUnit: ProposalOutcomeUnit.Percent,
       votingDuration: 48,
       discussionDuration: 48,
     },


### PR DESCRIPTION
- [ ] PR title equals to the ticket name
- [ ] I added the ticket to the `Development` section of this PR.

### What was changed?
- [ ] Added `minApproveUnit: percent` and `maxRejectUnit: percent` to circle definition
