### PR TITLE
System messages in the General should appear without "system:" in the lastMessage preview #1745

### DIFF
--- a/src/pages/commonFeed/utils/getLastMessage.ts
+++ b/src/pages/commonFeed/utils/getLastMessage.ts
@@ -1,4 +1,5 @@
 import { GetLastMessageOptions } from "@/pages/common";
+import { DiscussionMessageOwnerType } from "@/shared/constants";
 import { CommonFeedType, PredefinedTypes } from "@/shared/models";
 import {
   checkIsTextEditorValueEmpty,
@@ -71,9 +72,13 @@ export const getLastMessage = (
   );
 
   const hasText = !checkIsTextEditorValueEmpty(parsedMessageContent);
+  const userName =
+    lastMessage.ownerType === DiscussionMessageOwnerType.System
+      ? ""
+      : `${lastMessage.userName}: `;
 
   return prependTextInTextEditorValue(
-    `${lastMessage.userName}: ${getLastMessageIconWithText({
+    `${userName}${getLastMessageIconWithText({
       hasText,
       hasImages,
       hasFiles,

--- a/src/pages/inbox/components/ChatChannelItem/ChatChannelItem.tsx
+++ b/src/pages/inbox/components/ChatChannelItem/ChatChannelItem.tsx
@@ -9,7 +9,6 @@ import { useChatChannelUserStatus, useUserById } from "@/shared/hooks/useCases";
 import { useIsTabletView } from "@/shared/hooks/viewport";
 import { ChatChannelFeedLayoutItemProps } from "@/shared/interfaces";
 import { ChatChannel } from "@/shared/models";
-import { parseStringToTextEditorValue } from "@/shared/ui-kit";
 import { getUserName } from "@/shared/utils";
 import { inboxActions } from "@/store/states";
 import { FeedItemBaseContent } from "../FeedItemBaseContent";

--- a/src/pages/inbox/utils/getLastMessage.ts
+++ b/src/pages/inbox/utils/getLastMessage.ts
@@ -1,5 +1,6 @@
 import { GetLastMessageOptions } from "@/pages/common";
 import { getLastMessageIconWithText } from "@/pages/commonFeed/utils";
+import { DiscussionMessageOwnerType } from "@/shared/constants";
 import {
   checkIsTextEditorValueEmpty,
   parseStringToTextEditorValue,
@@ -21,9 +22,13 @@ export const getLastMessage = (
   );
 
   const hasText = !checkIsTextEditorValueEmpty(parsedMessageContent);
+  const userName =
+    lastMessage.ownerType === DiscussionMessageOwnerType.System
+      ? ""
+      : `${lastMessage.userName}: `;
 
   return prependTextInTextEditorValue(
-    `${lastMessage.userName}: ${getLastMessageIconWithText({
+    `${userName}${getLastMessageIconWithText({
       hasText,
       hasImages,
       hasFiles,

--- a/src/shared/models/CommonFeed.tsx
+++ b/src/shared/models/CommonFeed.tsx
@@ -1,3 +1,4 @@
+import { DiscussionMessageOwnerType } from "@/shared/constants";
 import { BaseEntity } from "./BaseEntity";
 import { SoftDeleteEntity } from "./SoftDeleteEntity";
 
@@ -19,6 +20,7 @@ export interface CommonFeed extends BaseEntity, SoftDeleteEntity {
     lastMessage?: {
       userName: string;
       content: string;
+      ownerType?: DiscussionMessageOwnerType;
     };
     hasFiles?: boolean;
     hasImages?: boolean;


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] removed `System: ` text from last message preview
