### PR TITLE
Show image\file in the last message preview for dm - 2 #1714

### DIFF
--- a/src/pages/inbox/components/ChatChannelItem/utils/getLastMessage.ts
+++ b/src/pages/inbox/components/ChatChannelItem/utils/getLastMessage.ts
@@ -10,7 +10,7 @@ import {
 export const getLastMessage = (
   lastMessage: ChatChannel["lastMessage"],
 ): TextEditorValue | undefined => {
-  if (!lastMessage?.text) {
+  if (!lastMessage) {
     return;
   }
 


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fixed files icon displaying for message with empty text
