### PR TITLE
Fix images positions in chat messages on mobile (android) #1803

### DIFF
--- a/src/shared/components/Chat/ChatMessage/ChatMessage.module.scss
+++ b/src/shared/components/Chat/ChatMessage/ChatMessage.module.scss
@@ -60,6 +60,7 @@
   box-sizing: border-box;
   position: relative;
   text-align: start;
+  width: 100%;
 
   &:hover {
     .menuArrowButton {
@@ -268,4 +269,3 @@
 .multipleEmojiText {
   font-size: $large;
 }
-

--- a/src/shared/ui-kit/ImageGallery/ChatImageGallery.module.scss
+++ b/src/shared/ui-kit/ImageGallery/ChatImageGallery.module.scss
@@ -4,7 +4,6 @@
 .container {
   position: relative;
   margin-bottom: 0.125rem;
-  width: 15.4375rem;
   cursor: pointer;
 }
 
@@ -47,8 +46,8 @@
 .singleImage {
   max-width: 15.4375rem;
   max-height: 16.625rem;
-  width: 15.4375rem;
-  height: 16.625rem;
+  width: 100%;
+  height: 100%;
 }
 
 .singleImageContainer {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Chat mobile: fix images overflow.
