### PR TITLE
when edit a space there is a message that name already exist #1822

### DIFF
--- a/src/pages/commonCreation/components/ProjectCreation/components/ProjectCreationForm/ProjectCreationForm.tsx
+++ b/src/pages/commonCreation/components/ProjectCreation/components/ProjectCreationForm/ProjectCreationForm.tsx
@@ -75,7 +75,6 @@ const ProjectCreationForm: FC<ProjectCreationFormProps> = (props) => {
   } = props;
   const dispatch = useDispatch();
   const projects = useSelector(selectCommonLayoutProjects);
-  const existingProjectsNames = projects.map((project) => project?.name);
 
   const formRef = useRef<CreationFormRef>(null);
   const {
@@ -96,6 +95,10 @@ const ProjectCreationForm: FC<ProjectCreationFormProps> = (props) => {
     () => getInitialValues(governanceCircles, initialCommon),
     [governanceCircles],
   );
+
+  const existingProjectsNames = projects
+    .map((project) => project?.name)
+    .filter((spaceName) => spaceName !== initialValues?.spaceName);
 
   const shouldPreventReload = useCallback(
     () => (!project && !updatedProject && formRef.current?.isDirty()) ?? true,


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Edit space: fix issue that "name already exists" is displayed even without changing the name field.
