### PR TITLE
parsing error in ChatMessage #1836

### DIFF
--- a/src/shared/components/Chat/ChatMessage/ChatMessage.tsx
+++ b/src/shared/components/Chat/ChatMessage/ChatMessage.tsx
@@ -122,6 +122,11 @@ export default function ChatMessage({
 
   useEffect(() => {
     (async () => {
+      if (!discussionMessage.text) {
+        setMessageText([]);
+        return;
+      }
+
       const emojiCount = countTextEditorEmojiElements(
         JSON.parse(discussionMessage.text),
       );


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] added setting of empty array as message text when discussionMessage text is empty
