### PR TITLE
when edit a space with no picture- the icon doesnt shown #1819

### DIFF
--- a/src/pages/commonEditing/components/Editing/components/EditingForm/EditingForm.tsx
+++ b/src/pages/commonEditing/components/Editing/components/EditingForm/EditingForm.tsx
@@ -29,13 +29,15 @@ interface EditingFormProps {
 
 const getInitialValues = (common: Common): EditingFormValues => {
   return {
-    projectImages: [
-      {
-        id: "common_image",
-        title: "common_image",
-        file: common.image,
-      },
-    ],
+    projectImages: common.image
+      ? [
+          {
+            id: "common_image",
+            title: "common_image",
+            file: common.image,
+          },
+        ]
+      : [],
     spaceName: common.name,
     byline: common.byline || "",
     description: parseStringToTextEditorValue(common.description),


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fixed common editing page with no image
