### PR TITLE
chat- when upload an image without text - the preview is empty #1850

### DIFF
--- a/src/shared/ui-kit/TextEditor/utils/prependTextInTextEditorValue.ts
+++ b/src/shared/ui-kit/TextEditor/utils/prependTextInTextEditorValue.ts
@@ -1,15 +1,20 @@
 import { Element } from "slate";
 import { ElementType } from "@/shared/ui-kit/TextEditor/constants";
 import { TextEditorValue } from "../types";
+import { checkIsTextEditorValueEmpty } from "./checkIsTextEditorValueEmpty";
+import { parseStringToTextEditorValue } from "./parseStringToTextEditorValue";
 
 export const prependTextInTextEditorValue = (
   text: string,
-  value: TextEditorValue,
+  initialValue: TextEditorValue,
 ): TextEditorValue => {
   if (!text) {
-    return value;
+    return initialValue;
   }
 
+  const value = checkIsTextEditorValueEmpty(initialValue)
+    ? parseStringToTextEditorValue()
+    : initialValue;
   const firstElement = value[0];
 
   if (


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fixed `prependTextInTextEditorValue` util to use known default empty text editor value when needed
