### PR TITLE
inbox -when following discussions in two commons - only one of them appear #1881

### DIFF
--- a/src/pages/common/components/FeedItem/FeedItem.tsx
+++ b/src/pages/common/components/FeedItem/FeedItem.tsx
@@ -29,6 +29,7 @@ interface FeedItemProps {
   isActive?: boolean;
   isExpanded?: boolean;
   sizeKey?: string;
+  shouldCheckItemVisibility?: boolean;
 }
 
 const FeedItem: FC<FeedItemProps> = (props) => {
@@ -49,12 +50,14 @@ const FeedItem: FC<FeedItemProps> = (props) => {
     isExpanded = false,
     sizeKey,
     currentUserId,
+    shouldCheckItemVisibility = true,
   } = props;
   const { onFeedItemUpdate, getLastMessage, getNonAllowedItems } =
     useFeedItemContext();
   useFeedItemSubscription(item.id, commonId, onFeedItemUpdate);
 
   if (
+    shouldCheckItemVisibility &&
     !checkIsItemVisibleForUser(
       item.circleVisibility,
       userCircleIds,

--- a/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
@@ -368,6 +368,10 @@ const FeedLayout: ForwardRefRenderFunction<FeedLayoutRef, FeedLayoutProps> = (
                         isExpanded={item.feedItem.id === expandedFeedItemId}
                         sizeKey={isActive ? sizeKey : undefined}
                         currentUserId={userId}
+                        shouldCheckItemVisibility={
+                          !item.feedItemFollowWithMetadata ||
+                          item.feedItemFollowWithMetadata.userId !== userId
+                        }
                       />
                     );
                   }


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] added logic to skip feed item visibility check when there is feed item metadata, because `userCircleIds` prop which we pass is correct only when the item is selected. but for the case with inbox we can omit this check because user should see all items which he is following
