### PR TITLE
Wrong role shown when click on a user name #1888

### DIFF
--- a/src/pages/OldCommon/hooks/useCommonMember.ts
+++ b/src/pages/OldCommon/hooks/useCommonMember.ts
@@ -23,6 +23,7 @@ interface Options {
   withSubscription?: boolean;
   commonId?: string;
   governanceCircles?: Circles;
+  userId?: string;
 }
 
 type State = LoadingState<(CommonMember & CirclesPermissions) | null>;
@@ -32,7 +33,6 @@ interface Return extends State {
     commonId: string,
     options: { governance?: Governance; commonMember?: CommonMember },
     force?: boolean,
-    userId?: string,
   ) => void;
   setCommonMember: (
     commonMember: (CommonMember & CirclesPermissions) | null,
@@ -53,7 +53,7 @@ export const useCommonMember = (options: Options = {}): Return => {
     data: null,
   });
   const user = useSelector(selectUser());
-  const userId = user?.uid;
+  const userId = options.userId || user?.uid;
   const commonMemberId = state.data?.id;
 
   const fetchCommonMember = useCallback(
@@ -61,7 +61,6 @@ export const useCommonMember = (options: Options = {}): Return => {
       commonId: string,
       options: { governance?: Governance; commonMember?: CommonMember } = {},
       force = false,
-      userId?: string,
     ) => {
       if (!force && (state.loading || state.fetched)) {
         return;

--- a/src/shared/hooks/useCases/useCommonMemberWithUserInfo.ts
+++ b/src/shared/hooks/useCases/useCommonMemberWithUserInfo.ts
@@ -29,17 +29,15 @@ export const useCommonMemberWithUserInfo = (
     fetchCommonMember,
     loading: isCommonMemberLoading,
     fetched: isCommonMemberFetched,
-  } = useCommonMember();
+  } = useCommonMember({ userId });
 
   useEffect(() => {
     if (userId) {
       fetchUser(userId);
     }
     if (commonId) {
+      fetchCommonMember(commonId, {}, true);
       fetchGovernance(commonId);
-    }
-    if (userId && commonId) {
-      fetchCommonMember(commonId, {}, true, userId);
     }
   }, [userId, commonId]);
 


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] `UserInfoPopup`: fix wrong circle text in some cases ; eliminate the use of `useCommonMember` old hook.
