### PR TITLE
show Add a space button only for active tree item #1893

### DIFF
--- a/src/shared/layouts/CommonSidenavLayout/components/SidenavContent/components/ProjectsTree/ProjectsTree.tsx
+++ b/src/shared/layouts/CommonSidenavLayout/components/SidenavContent/components/ProjectsTree/ProjectsTree.tsx
@@ -88,7 +88,9 @@ const ProjectsTree: FC<ProjectsTreeProps> = (props) => {
           parentId={parentItem.id}
           parentName={parentItem.name}
           items={items}
-          hasPermissionToAddProject={parentItem.hasPermissionToAddProject}
+          hasPermissionToAddProject={
+            parentItem.hasPermissionToAddProject && isParentItemActive
+          }
           level={INITIAL_TREE_ITEMS_LEVEL}
         />
         {isLoading && <Loader className={styles.loader} />}

--- a/src/shared/layouts/SidenavLayout/components/SidenavContent/components/ProjectsTree/components/TreeRecursive/TreeRecursive.tsx
+++ b/src/shared/layouts/SidenavLayout/components/SidenavContent/components/ProjectsTree/components/TreeRecursive/TreeRecursive.tsx
@@ -52,26 +52,27 @@ const TreeRecursive: FC<TreeRecursiveProps> = (props) => {
           : "List of related to you spaces"
       }
     >
-      {items.map((item) => (
-        <TreeItem
-          key={item.id}
-          item={item}
-          level={level}
-          isActive={isActiveCheckAllowed && item.id === activeItemId}
-        >
-          {(item.items && item.items.length > 0) ||
-          item.id === itemIdWithNewProjectCreation ||
-          item.hasPermissionToAddProject ? (
-            <TreeRecursive
-              items={item.items || []}
-              parentId={item.id}
-              parentName={item.name}
-              hasPermissionToAddProject={item.hasPermissionToAddProject}
-              level={level + 1}
-            />
-          ) : null}
-        </TreeItem>
-      ))}
+      {items.map((item) => {
+        const isActive = isActiveCheckAllowed && item.id === activeItemId;
+        const hasPermissionToAddProject =
+          item.hasPermissionToAddProject && isActive;
+
+        return (
+          <TreeItem key={item.id} item={item} level={level} isActive={isActive}>
+            {(item.items && item.items.length > 0) ||
+            item.id === itemIdWithNewProjectCreation ||
+            hasPermissionToAddProject ? (
+              <TreeRecursive
+                items={item.items || []}
+                parentId={item.id}
+                parentName={item.name}
+                hasPermissionToAddProject={hasPermissionToAddProject}
+                level={level + 1}
+              />
+            ) : null}
+          </TreeItem>
+        );
+      })}
       {isTreeWithNewSpaceCreation && (
         <PlaceholderTreeItem
           imageClassName={styles.newProjectImage}


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] added logic to display `Add a space` button only for active tree item
