### PR TITLE
main bar- when creating a proposal it should stay opened #1862

### DIFF
--- a/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
@@ -250,7 +250,11 @@ const FeedLayout: ForwardRefRenderFunction<FeedLayoutRef, FeedLayoutProps> = (
   );
 
   const setActiveChatItem = useCallback((nextChatItem: ChatItem | null) => {
-    setExpandedFeedItemId(null);
+    setExpandedFeedItemId((currentExpandedFeedItemId) =>
+      currentExpandedFeedItemId === nextChatItem?.feedItemId
+        ? currentExpandedFeedItemId
+        : null,
+    );
     setChatItem(nextChatItem);
   }, []);
 


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fixed auto opening of created streams by not clearing expanded feed item id if new active item has same feed item id
