### PR TITLE
Circles dropdown in space updates #1926

### DIFF
--- a/src/pages/common/components/CommonMemberInfo/components/PopoverItem/PopoverItem.tsx
+++ b/src/pages/common/components/CommonMemberInfo/components/PopoverItem/PopoverItem.tsx
@@ -90,6 +90,10 @@ export const PopoverItem: FC<CommonMemberInfoProps> = (props) => {
       return <p className={styles.pendingStatus}>Pending</p>;
     }
 
+    if (!canRequestToJoin) {
+      return <></>;
+    }
+
     return (
       <Button
         className={styles.actionButton}


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Circles dropdown in space: hide "request to join" button in case it's the last circle.
