### PR TITLE
Mobile chat title: space/common name instead of 'General'

### DIFF
--- a/src/pages/commonFeed/components/FeedLayout/components/MobileChat/MobileChat.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/components/MobileChat/MobileChat.tsx
@@ -15,6 +15,7 @@ import {
   CirclesPermissions,
   CommonMember,
   DirectParent,
+  PredefinedTypes,
 } from "@/shared/models";
 import { getUserName } from "@/shared/utils";
 import { Header } from "./components";
@@ -64,7 +65,11 @@ const MobileChat: FC<ChatProps> = (props) => {
   const dmUserId = chatItem?.chatChannel?.participants.filter(
     (participant) => participant !== userId,
   )[0];
-  const title = getUserName(dmUser) || chatItem?.discussion.title || "";
+  const title =
+    getUserName(dmUser) ||
+    chatItem?.discussion.predefinedType === PredefinedTypes.General
+      ? commonName
+      : chatItem?.discussion.title || "";
 
   const hasAccessToChat = useMemo(
     () => checkHasAccessToChat(userCircleIds, chatItem),


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] mobile chat: show the name of the common/space instead of 'General'.
