### PR TITLE
when last message is of the user - should appear as "you" and not his name #1561

### DIFF
--- a/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
+++ b/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
@@ -293,6 +293,7 @@ const DiscussionFeedCard: FC<DiscussionFeedCardProps> = (props) => {
           isProject,
           hasFiles: item.data.hasFiles,
           hasImages: item.data.hasImages,
+          ownerId: item.userId,
         })}
         isPreviewMode={isPreviewMode}
         isPinned={isPinned}

--- a/src/pages/common/components/ProposalFeedCard/ProposalFeedCard.tsx
+++ b/src/pages/common/components/ProposalFeedCard/ProposalFeedCard.tsx
@@ -384,6 +384,7 @@ const ProposalFeedCard: React.FC<ProposalFeedCardProps> = (props) => {
           isProject,
           hasFiles: item.data.hasFiles,
           hasImages: item.data.hasImages,
+          ownerId: item.userId,
         })}
         canBeExpanded={discussion?.predefinedType !== PredefinedTypes.General}
         isPreviewMode={isPreviewMode}

--- a/src/pages/commonFeed/utils/getLastMessage.ts
+++ b/src/pages/commonFeed/utils/getLastMessage.ts
@@ -61,7 +61,7 @@ export const getLastMessageIconWithText = ({
 export const getLastMessage = (
   options: GetLastMessageOptions,
 ): TextEditorValue => {
-  const { lastMessage, hasImages, hasFiles } = options;
+  const { lastMessage, hasImages, hasFiles, ownerId, currentUserId } = options;
 
   if (!lastMessage) {
     return parseStringToTextEditorValue(getCustomizedMessageString(options));
@@ -75,7 +75,7 @@ export const getLastMessage = (
   const userName =
     lastMessage.ownerType === DiscussionMessageOwnerType.System
       ? ""
-      : `${lastMessage.userName}: `;
+      : `${ownerId === currentUserId ? "You" : lastMessage.userName}: `;
 
   return prependTextInTextEditorValue(
     `${userName}${getLastMessageIconWithText({

--- a/src/pages/inbox/utils/getLastMessage.ts
+++ b/src/pages/inbox/utils/getLastMessage.ts
@@ -11,7 +11,14 @@ import {
 export const getLastMessage = (
   options: GetLastMessageOptions,
 ): TextEditorValue => {
-  const { lastMessage, hasImages, hasFiles, commonName } = options;
+  const {
+    lastMessage,
+    hasImages,
+    hasFiles,
+    commonName,
+    ownerId,
+    currentUserId,
+  } = options;
 
   if (!lastMessage) {
     return parseStringToTextEditorValue(commonName);
@@ -25,7 +32,7 @@ export const getLastMessage = (
   const userName =
     lastMessage.ownerType === DiscussionMessageOwnerType.System
       ? ""
-      : `${lastMessage.userName}: `;
+      : `${ownerId === currentUserId ? "You" : lastMessage.userName}: `;
 
   return prependTextInTextEditorValue(
     `${userName}${getLastMessageIconWithText({


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] when last message is of the current user - it appears as "you" and not his name.
