### PR TITLE
home channel- wrong name in the preview #1966

### DIFF
--- a/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
+++ b/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
@@ -298,7 +298,6 @@ const DiscussionFeedCard: FC<DiscussionFeedCardProps> = (props) => {
           isProject,
           hasFiles: item.data.hasFiles,
           hasImages: item.data.hasImages,
-          ownerId: item.userId,
         })}
         isPreviewMode={isPreviewMode}
         isPinned={isPinned}

--- a/src/pages/common/components/ProposalFeedCard/ProposalFeedCard.tsx
+++ b/src/pages/common/components/ProposalFeedCard/ProposalFeedCard.tsx
@@ -389,7 +389,6 @@ const ProposalFeedCard: React.FC<ProposalFeedCardProps> = (props) => {
           isProject,
           hasFiles: item.data.hasFiles,
           hasImages: item.data.hasImages,
-          ownerId: item.userId,
         })}
         canBeExpanded={discussion?.predefinedType !== PredefinedTypes.General}
         isPreviewMode={isPreviewMode}

--- a/src/pages/commonFeed/utils/getLastMessage.ts
+++ b/src/pages/commonFeed/utils/getLastMessage.ts
@@ -61,7 +61,7 @@ export const getLastMessageIconWithText = ({
 export const getLastMessage = (
   options: GetLastMessageOptions,
 ): TextEditorValue => {
-  const { lastMessage, hasImages, hasFiles, ownerId, currentUserId } = options;
+  const { lastMessage, hasImages, hasFiles, currentUserId } = options;
 
   if (!lastMessage) {
     return parseStringToTextEditorValue(getCustomizedMessageString(options));
@@ -75,7 +75,9 @@ export const getLastMessage = (
   const userName =
     lastMessage.ownerType === DiscussionMessageOwnerType.System
       ? ""
-      : `${ownerId === currentUserId ? "You" : lastMessage.userName}: `;
+      : `${
+          lastMessage.ownerId === currentUserId ? "You" : lastMessage.userName
+        }: `;
 
   return prependTextInTextEditorValue(
     `${userName}${getLastMessageIconWithText({

--- a/src/pages/inbox/utils/getLastMessage.ts
+++ b/src/pages/inbox/utils/getLastMessage.ts
@@ -11,14 +11,8 @@ import {
 export const getLastMessage = (
   options: GetLastMessageOptions,
 ): TextEditorValue => {
-  const {
-    lastMessage,
-    hasImages,
-    hasFiles,
-    commonName,
-    ownerId,
-    currentUserId,
-  } = options;
+  const { lastMessage, hasImages, hasFiles, commonName, currentUserId } =
+    options;
 
   if (!lastMessage) {
     return parseStringToTextEditorValue(commonName);
@@ -32,7 +26,9 @@ export const getLastMessage = (
   const userName =
     lastMessage.ownerType === DiscussionMessageOwnerType.System
       ? ""
-      : `${ownerId === currentUserId ? "You" : lastMessage.userName}: `;
+      : `${
+          lastMessage.ownerId === currentUserId ? "You" : lastMessage.userName
+        }: `;
 
   return prependTextInTextEditorValue(
     `${userName}${getLastMessageIconWithText({

--- a/src/shared/components/Chat/ChatMessage/utils/getTextFromSystemMessage.tsx
+++ b/src/shared/components/Chat/ChatMessage/utils/getTextFromSystemMessage.tsx
@@ -7,7 +7,6 @@ import {
   CommonCreatedSystemMessage,
   CommonEditedSystemMessage,
   CommonMemberAddedSystemMessage,
-  DirectParent,
   SystemMessageCommonType,
   User,
 } from "@/shared/models";

--- a/src/shared/models/CommonFeed.tsx
+++ b/src/shared/models/CommonFeed.tsx
@@ -20,6 +20,7 @@ export interface CommonFeed extends BaseEntity, SoftDeleteEntity {
     discussionId: string | null;
     lastMessage?: {
       userName: string;
+      ownerId: string;
       content: string;
       ownerType?: DiscussionMessageOwnerType;
     };


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fix: wrong name in preview of last message for a feed card - use `ownerId` of `lastMessage` now.
