### PR TITLE
Inbox last message preview appears only after clicking another item #1980

### DIFF
--- a/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
+++ b/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
@@ -143,8 +143,7 @@ const DiscussionFeedCard: FC<DiscussionFeedCardProps> = (props) => {
     !isDiscussionCreatorFetched ||
     !isDiscussionFetched ||
     !isFeedItemUserMetadataFetched ||
-    !commonId ||
-    !governanceCircles;
+    !commonId;
   const cardTitle = discussion?.title;
 
   const handleOpenChat = useCallback(() => {
@@ -229,10 +228,9 @@ const DiscussionFeedCard: FC<DiscussionFeedCardProps> = (props) => {
       return null;
     }
 
-    const circleVisibility = getVisibilityString(
-      governanceCircles,
-      discussion?.circleVisibility,
-    );
+    const circleVisibility = governanceCircles
+      ? getVisibilityString(governanceCircles, discussion?.circleVisibility)
+      : undefined;
 
     const isHome = discussion?.predefinedType === PredefinedTypes.General;
 


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] removed `governanceCircles` check for loading flag in discussion card
