### PR TITLE
Add "Tap to see more" option for Home streams on mobile (similar to other streams) #1970

### DIFF
--- a/src/pages/commonFeed/components/FeedLayout/components/MobileChat/MobileChat.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/components/MobileChat/MobileChat.tsx
@@ -69,9 +69,9 @@ const MobileChat: FC<ChatProps> = (props) => {
   )[0];
   const title =
     getUserName(dmUser) ||
-    chatItem?.discussion.predefinedType === PredefinedTypes.General
+    (chatItem?.discussion.predefinedType === PredefinedTypes.General
       ? commonName
-      : chatItem?.discussion.title || "";
+      : chatItem?.discussion.title || "");
 
   const hasAccessToChat = useMemo(
     () => checkHasAccessToChat(userCircleIds, chatItem),


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/1970

### What was changed?
- Fixed condition for mobile title
