### PR TITLE
Inbox - remove "Edit" and "Delete" options from the cards actions menu #2022

### DIFF
--- a/src/pages/inbox/utils/getNonAllowedItems.ts
+++ b/src/pages/inbox/utils/getNonAllowedItems.ts
@@ -1,15 +1,8 @@
 import { FeedItemMenuItem, GetNonAllowedItemsOptions } from "@/pages/common";
-import { CommonFeedType } from "@/shared/models";
 
-export const getNonAllowedItems: GetNonAllowedItemsOptions = (type) => {
-  const items: FeedItemMenuItem[] = [
-    FeedItemMenuItem.Pin,
-    FeedItemMenuItem.Unpin,
-  ];
-
-  if (type !== CommonFeedType.Discussion) {
-    items.push(FeedItemMenuItem.Remove);
-  }
-
-  return items;
-};
+export const getNonAllowedItems: GetNonAllowedItemsOptions = () => [
+  FeedItemMenuItem.Pin,
+  FeedItemMenuItem.Unpin,
+  FeedItemMenuItem.Edit,
+  FeedItemMenuItem.Remove,
+];


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] removed `Edit` and `Delete` options from inbox items
