### PR TITLE
FE mark as unread\read functionality #2017

### DIFF
--- a/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
+++ b/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
@@ -135,6 +135,7 @@ const DiscussionFeedCard = forwardRef<FeedItemRef, DiscussionFeedCardProps>(
         commonMember,
         feedItemFollow,
         getNonAllowedItems,
+        feedItemUserMetadata,
       },
       {
         report: onReportModalOpen,
@@ -324,6 +325,7 @@ const DiscussionFeedCard = forwardRef<FeedItemRef, DiscussionFeedCardProps>(
           isLoading={isLoading}
           menuItems={menuItems}
           seenOnce={feedItemUserMetadata?.seenOnce}
+          seen={feedItemUserMetadata?.seen}
           ownerId={item.userId}
           discussionPredefinedType={discussion?.predefinedType}
         >

--- a/src/pages/common/components/DiscussionFeedCard/hooks/useMenuItems.tsx
+++ b/src/pages/common/components/DiscussionFeedCard/hooks/useMenuItems.tsx
@@ -12,6 +12,7 @@ import {
   Trash2Icon,
   UnfollowIcon,
   UnpinIcon,
+  Message3Icon,
 } from "@/shared/icons";
 import { ContextMenuItem as Item, UploadFile } from "@/shared/interfaces";
 import { parseStringToTextEditorValue } from "@/shared/ui-kit";
@@ -31,7 +32,13 @@ export const useMenuItems = (
   actions: Actions,
 ): Item[] => {
   const dispatch = useDispatch();
-  const { discussion, commonId, feedItem, feedItemFollow } = options;
+  const {
+    discussion,
+    commonId,
+    feedItem,
+    feedItemFollow,
+    feedItemUserMetadata,
+  } = options;
   const { report, share, remove } = actions;
   const allowedMenuItems = getAllowedItems({ ...options, feedItemFollow });
   const items: Item[] = [
@@ -58,6 +65,38 @@ export const useMenuItems = (
       text: "Share",
       onClick: share,
       icon: <Share3Icon />,
+    },
+    {
+      id: FeedItemMenuItem.MarkUnread,
+      text: "Mark as unread",
+      onClick: async () => {
+        if (!commonId || !feedItem) {
+          return;
+        }
+
+        await CommonFeedService.markCommonFeedItemAsUnseen(
+          commonId,
+          feedItem.id,
+        );
+      },
+      icon: <Message3Icon />,
+    },
+    {
+      id: FeedItemMenuItem.MarkRead,
+      text: "Mark as read",
+      onClick: async () => {
+        if (!commonId || !feedItem) {
+          return;
+        }
+
+        await CommonFeedService.markCommonFeedItemAsSeen({
+          commonId,
+          feedObjectId: feedItem.id,
+          lastSeenId: feedItemUserMetadata?.lastSeen?.id,
+          type: feedItemUserMetadata?.lastSeen?.type,
+        });
+      },
+      icon: <Message3Icon />,
     },
     {
       id: FeedItemMenuItem.Report,

--- a/src/pages/common/components/DiscussionFeedCard/utils/getAllowedItems.ts
+++ b/src/pages/common/components/DiscussionFeedCard/utils/getAllowedItems.ts
@@ -1,4 +1,5 @@
 import { CommonFeedType } from "@/shared/models";
+import { notEmpty } from "@/shared/utils/notEmpty";
 import { FeedItemMenuItem, FeedItemPinAction } from "../../FeedItem/constants";
 import { GetAllowedItemsOptions } from "../../FeedItem/types";
 import { checkIsEditItemAllowed } from "./checkIsEditItemAllowed";
@@ -27,6 +28,16 @@ const MENU_ITEM_TO_CHECK_FUNCTION_MAP: Record<
       !options.feedItemFollow.isDisabled && options.feedItemFollow.isFollowing
     );
   },
+  [FeedItemMenuItem.MarkUnread]: ({ feedItemUserMetadata }) => {
+    const { count, seen } = feedItemUserMetadata || {};
+
+    return notEmpty(count) && notEmpty(seen) && count === 0 && seen;
+  },
+  [FeedItemMenuItem.MarkRead]: ({ feedItemUserMetadata }) => {
+    const { count, seen } = feedItemUserMetadata || {};
+
+    return Boolean(count) || !seen;
+  },
 };
 
 export const getAllowedItems = (
@@ -38,6 +49,8 @@ export const getAllowedItems = (
     FeedItemMenuItem.Pin,
     FeedItemMenuItem.Unpin,
     FeedItemMenuItem.Share,
+    FeedItemMenuItem.MarkUnread,
+    FeedItemMenuItem.MarkRead,
     FeedItemMenuItem.Report,
     FeedItemMenuItem.Edit,
     FeedItemMenuItem.Remove,

--- a/src/pages/common/components/FeedCard/FeedCard.tsx
+++ b/src/pages/common/components/FeedCard/FeedCard.tsx
@@ -40,6 +40,7 @@ type FeedCardProps = PropsWithChildren<{
   type?: CommonFeedType;
   menuItems?: ContextMenuItem[];
   seenOnce?: boolean;
+  seen?: boolean;
   ownerId?: string;
   discussionPredefinedType?: PredefinedTypes;
   hasFiles?: boolean;
@@ -77,6 +78,7 @@ export const FeedCard = forwardRef<FeedCardRef, FeedCardProps>((props, ref) => {
     type,
     menuItems,
     seenOnce,
+    seen,
     ownerId,
     discussionPredefinedType,
     hasImages,
@@ -197,6 +199,7 @@ export const FeedCard = forwardRef<FeedCardRef, FeedCardProps>((props, ref) => {
             isFollowing,
             type,
             seenOnce,
+            seen,
             ownerId,
             discussionPredefinedType,
             hasFiles,

--- a/src/pages/common/components/FeedCard/components/FeedCardTags/FeedCardTags.module.scss
+++ b/src/pages/common/components/FeedCard/components/FeedCardTags/FeedCardTags.module.scss
@@ -50,3 +50,9 @@
   margin-left: 0.75rem;
   color: $c-gray-800;
 }
+
+.unseen {
+  width: 1.4375rem;
+  border-radius: 50%;
+  background-color: $c-pink-primary;
+}

--- a/src/pages/common/components/FeedCard/components/FeedCardTags/FeedCardTags.tsx
+++ b/src/pages/common/components/FeedCard/components/FeedCardTags/FeedCardTags.tsx
@@ -4,12 +4,14 @@ import classNames from "classnames";
 import { selectUser } from "@/pages/Auth/store/selectors";
 import { PinIcon, StarIcon } from "@/shared/icons";
 import { CommonFeedType } from "@/shared/models";
+import { notEmpty } from "@/shared/utils/notEmpty";
 import styles from "./FeedCardTags.module.scss";
 
 interface FeedCardTagsProps {
   unreadMessages?: number;
   type?: CommonFeedType;
   seenOnce?: boolean;
+  seen?: boolean;
   ownerId?: string;
   isActive: boolean;
   isPinned?: boolean;
@@ -21,6 +23,7 @@ export const FeedCardTags: FC<FeedCardTagsProps> = (props) => {
     unreadMessages,
     type,
     seenOnce,
+    seen,
     ownerId,
     isActive,
     isPinned,
@@ -68,6 +71,9 @@ export const FeedCardTags: FC<FeedCardTagsProps> = (props) => {
         >
           {unreadMessages}
         </div>
+      )}
+      {!unreadMessages && notEmpty(seen) && !seen && (
+        <div className={classNames(styles.tag, styles.unseen)}></div>
       )}
     </>
   );

--- a/src/pages/common/components/FeedCard/components/FeedItemBaseContent/FeedItemBaseContent.tsx
+++ b/src/pages/common/components/FeedCard/components/FeedItemBaseContent/FeedItemBaseContent.tsx
@@ -1,7 +1,6 @@
 import React, { FC, MouseEventHandler, useRef, useState } from "react";
 import classNames from "classnames";
 import { useLongPress } from "use-long-press";
-import { PredefinedTypes } from "@/shared/models";
 import {
   checkIsTextEditorValueEmpty,
   ContextMenu,
@@ -29,6 +28,7 @@ export const FeedItemBaseContent: FC<FeedItemBaseContentProps> = (props) => {
     type,
     menuItems,
     seenOnce,
+    seen,
     ownerId,
     renderLeftContent,
     isPinned,
@@ -149,6 +149,7 @@ export const FeedItemBaseContent: FC<FeedItemBaseContentProps> = (props) => {
                 unreadMessages={unreadMessages}
                 type={type}
                 seenOnce={seenOnce}
+                seen={seen}
                 ownerId={ownerId}
                 isActive={isActive}
                 isPinned={isPinned}

--- a/src/pages/common/components/FeedItem/FeedItem.tsx
+++ b/src/pages/common/components/FeedItem/FeedItem.tsx
@@ -15,6 +15,7 @@ import { DiscussionFeedCard } from "../DiscussionFeedCard";
 import { ProposalFeedCard } from "../ProposalFeedCard";
 import { ProjectFeedItem } from "./components";
 import { useFeedItemContext } from "./context";
+import { useFeedItemCounters } from "./hooks";
 import { FeedItemRef } from "./types";
 
 interface FeedItemProps {
@@ -67,6 +68,8 @@ const FeedItem = forwardRef<FeedItemRef, FeedItemProps>((props, ref) => {
   const { onFeedItemUpdate, getLastMessage, getNonAllowedItems, onUserSelect } =
     useFeedItemContext();
   useFeedItemSubscription(item.id, commonId, onFeedItemUpdate);
+  const { projectUnreadStreamsCount, projectUnreadMessages } =
+    useFeedItemCounters(item.id, commonId);
 
   if (
     shouldCheckItemVisibility &&
@@ -115,7 +118,14 @@ const FeedItem = forwardRef<FeedItemRef, FeedItemProps>((props, ref) => {
   }
 
   if (item.data.type === CommonFeedType.Project) {
-    return <ProjectFeedItem item={item} isMobileVersion={isMobileVersion} />;
+    return (
+      <ProjectFeedItem
+        item={item}
+        isMobileVersion={isMobileVersion}
+        unreadStreamsCount={projectUnreadStreamsCount}
+        unreadMessages={projectUnreadMessages}
+      />
+    );
   }
 
   return null;

--- a/src/pages/common/components/FeedItem/components/ProjectFeedItem/ProjectFeedItem.tsx
+++ b/src/pages/common/components/FeedItem/components/ProjectFeedItem/ProjectFeedItem.tsx
@@ -8,24 +8,21 @@ import { OpenIcon } from "@/shared/icons";
 import { CommonFeed } from "@/shared/models";
 import { CommonAvatar, parseStringToTextEditorValue } from "@/shared/ui-kit";
 import { checkIsProject } from "@/shared/utils";
-import { useFeedItemCounters } from "../../hooks";
 import styles from "./ProjectFeedItem.module.scss";
 
 interface ProjectFeedItemProps {
   item: CommonFeed;
   isMobileVersion: boolean;
+  unreadStreamsCount?: number;
+  unreadMessages?: number;
 }
 
 export const ProjectFeedItem: FC<ProjectFeedItemProps> = (props) => {
-  const { item, isMobileVersion } = props;
+  const { item, isMobileVersion, unreadStreamsCount, unreadMessages } = props;
   const history = useHistory();
   const { getCommonPagePath } = useRoutesContext();
   const { renderFeedItemBaseContent } = useFeedItemContext();
   const { data: common, fetched: isCommonFetched, fetchCommon } = useCommon();
-  const { unreadStreamsCount, unreadMessages } = useFeedItemCounters(
-    item.id,
-    common?.directParent?.commonId,
-  );
   const commonId = item.data.id;
   const lastMessage = parseStringToTextEditorValue(
     Number.isInteger(unreadStreamsCount)

--- a/src/pages/common/components/FeedItem/constants/feedItemMenuItem.ts
+++ b/src/pages/common/components/FeedItem/constants/feedItemMenuItem.ts
@@ -7,4 +7,6 @@ export enum FeedItemMenuItem {
   Remove = "remove",
   Follow = "follow",
   Unfollow = "unfollow",
+  MarkUnread = "markUnread",
+  MarkRead = "markRead",
 }

--- a/src/pages/common/components/FeedItem/context.ts
+++ b/src/pages/common/components/FeedItem/context.ts
@@ -26,6 +26,7 @@ export interface FeedItemBaseContentProps {
   menuItems?: ContextMenuItem[];
   type?: CommonFeedType;
   seenOnce?: boolean;
+  seen?: boolean;
   ownerId?: string;
   commonName?: string;
   renderImage?: (className?: string) => ReactNode;

--- a/src/pages/common/components/FeedItem/hooks/useFeedItemCounters.ts
+++ b/src/pages/common/components/FeedItem/hooks/useFeedItemCounters.ts
@@ -3,8 +3,8 @@ import { useCommonMember } from "@/pages/OldCommon/hooks";
 import { useGovernanceByCommonId } from "@/shared/hooks/useCases";
 
 interface Return {
-  unreadStreamsCount?: number;
-  unreadMessages?: number;
+  projectUnreadStreamsCount?: number;
+  projectUnreadMessages?: number;
 }
 
 export const useFeedItemCounters = (
@@ -28,7 +28,7 @@ export const useFeedItemCounters = (
   }, [fetchGovernance, commonId]);
 
   return {
-    unreadStreamsCount: streamsUnreadCountByProjectStream?.[feedItemId],
-    unreadMessages: unreadCountByProjectStream?.[feedItemId],
+    projectUnreadStreamsCount: streamsUnreadCountByProjectStream?.[feedItemId],
+    projectUnreadMessages: unreadCountByProjectStream?.[feedItemId],
   };
 };

--- a/src/pages/common/components/FeedItem/types.ts
+++ b/src/pages/common/components/FeedItem/types.ts
@@ -7,6 +7,7 @@ import {
   Discussion,
   Proposal,
   CommonFeedType,
+  CommonFeedObjectUserUnique,
 } from "@/shared/models";
 import { FeedItemMenuItem } from "./constants";
 
@@ -25,6 +26,7 @@ export interface GetAllowedItemsOptions {
   commonMember?: CommonMember | null;
   feedItemFollow: FeedItemFollowState;
   getNonAllowedItems?: GetNonAllowedItemsOptions;
+  feedItemUserMetadata: CommonFeedObjectUserUnique | null;
 }
 
 export type MenuItemOptions = Omit<GetAllowedItemsOptions, "feedItemFollow">;

--- a/src/pages/common/components/ProposalFeedCard/ProposalFeedCard.tsx
+++ b/src/pages/common/components/ProposalFeedCard/ProposalFeedCard.tsx
@@ -176,6 +176,7 @@ const ProposalFeedCard = forwardRef<FeedItemRef, ProposalFeedCardProps>(
         commonMember,
         feedItemFollow,
         getNonAllowedItems,
+        feedItemUserMetadata,
       },
       {
         report: () => {},
@@ -426,6 +427,7 @@ const ProposalFeedCard = forwardRef<FeedItemRef, ProposalFeedCardProps>(
           isLoading={isLoading}
           type={item.data.type}
           seenOnce={feedItemUserMetadata?.seenOnce}
+          seen={feedItemUserMetadata?.seen}
           menuItems={menuItems}
           ownerId={item.userId}
         >

--- a/src/pages/inbox/components/FeedItemBaseContent/FeedItemBaseContent.tsx
+++ b/src/pages/inbox/components/FeedItemBaseContent/FeedItemBaseContent.tsx
@@ -27,6 +27,7 @@ export const FeedItemBaseContent: FC<FeedItemBaseContentProps> = (props) => {
     type,
     menuItems,
     seenOnce,
+    seen,
     ownerId,
     commonName,
     renderImage,
@@ -155,6 +156,7 @@ export const FeedItemBaseContent: FC<FeedItemBaseContentProps> = (props) => {
               unreadMessages={unreadMessages}
               type={type}
               seenOnce={seenOnce}
+              seen={seen}
               ownerId={ownerId}
               isActive={isActive}
               isPinned={false}

--- a/src/services/CommonFeed.ts
+++ b/src/services/CommonFeed.ts
@@ -220,6 +220,16 @@ class CommonFeedService {
     return convertObjectDatesToFirestoreTimestamps(data);
   };
 
+  public markCommonFeedItemAsUnseen = (
+    commonId: string,
+    feedObjectId: string,
+  ) => {
+    return Api.post(ApiEndpoint.MarkFeedObjectUnseenForUser, {
+      commonId,
+      feedObjectId,
+    });
+  };
+
   public subscribeToCommonFeedItem = (
     commonId: string,
     feedItemId: string,

--- a/src/shared/constants/endpoint.ts
+++ b/src/shared/constants/endpoint.ts
@@ -6,6 +6,7 @@ export const ApiEndpoint = {
   UpdateCommon: "/commons/update",
   CreateSubCommon: "/commons/subcommon/create",
   MarkFeedObjectSeenForUser: "/commons/mark-feed-object-seen-for-user",
+  MarkFeedObjectUnseenForUser: "/commons/mark-feed-object-unseen-for-user",
   AcceptRules: "/commons/accept-rules",
   GetCommonFeedItems: "/commons/:commonId/feed-items",
   GetCommonPinnedFeedItems: "/commons/:commonId/pinned-feed-items",

--- a/src/shared/icons/index.ts
+++ b/src/shared/icons/index.ts
@@ -44,6 +44,7 @@ export { default as UploadIcon } from "./upload.icon";
 export { default as WalletIcon } from "./wallet.icon";
 export { default as MessageIcon } from "./message.icon";
 export { default as Message2Icon } from "./message2.icon";
+export { default as Message3Icon } from "./message3.icon";
 export { default as Trash2Icon } from "./trash2.icon";
 export { UnfollowIcon } from "./unfollow.icon";
 export { UnpinIcon } from "./unpin.icon";

--- a/src/shared/icons/message3.icon.tsx
+++ b/src/shared/icons/message3.icon.tsx
@@ -1,0 +1,37 @@
+import React, { FC } from "react";
+
+interface Message3IconProps {
+  className?: string;
+}
+
+const Message3Icon: FC<Message3IconProps> = ({ className }) => {
+  const color = "currentColor";
+
+  return (
+    <svg
+      className={className}
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 21V8a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v6a3 3 0 0 1-3 3H8l-4 4ZM9.5 9h.01"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14.5 9h.01M9.5 13a3.5 3.5 0 0 0 5 0"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default Message3Icon;

--- a/src/shared/models/CommonFeedObjectUserUnique.ts
+++ b/src/shared/models/CommonFeedObjectUserUnique.ts
@@ -4,7 +4,7 @@ import { Timestamp } from "./Timestamp";
 
 export interface CommonFeedObjectUserUnique extends BaseEntity {
   userId: string;
-  lastSeen: {
+  lastSeen?: {
     type: LastSeenEntity;
     id: string;
   };
@@ -13,4 +13,5 @@ export interface CommonFeedObjectUserUnique extends BaseEntity {
   feedObjectId: string;
   commonId: string;
   seenOnce?: boolean;
+  seen?: boolean;
 }


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Added new actions (mark as read/unread) to the feed item action menu
