### PR TITLE
when create a new discussion/proposal- the chat remains open with previews channel details #1990

### DIFF
--- a/src/pages/common/components/ChatComponent/context.ts
+++ b/src/pages/common/components/ChatComponent/context.ts
@@ -11,7 +11,7 @@ export interface ChatItem {
   proposal?: Proposal;
   discussion?: Discussion;
   chatChannel?: ChatChannel;
-  circleVisibility: string[];
+  circleVisibility?: string[];
   lastSeenItem?: CommonFeedObjectUserUnique["lastSeen"];
   lastSeenAt?: CommonFeedObjectUserUnique["lastSeenAt"];
   seenOnce?: boolean;

--- a/src/pages/common/components/CommonTabPanels/components/FeedTab/utils/checkHasAccessToChat.ts
+++ b/src/pages/common/components/CommonTabPanels/components/FeedTab/utils/checkHasAccessToChat.ts
@@ -8,10 +8,10 @@ export const checkHasAccessToChat = (
     return false;
   }
 
+  const { circleVisibility = [] } = chatItem;
+
   return (
-    !chatItem.circleVisibility.length ||
-    chatItem.circleVisibility.some((circleId) =>
-      userCircleIds.includes(circleId),
-    )
+    !circleVisibility.length ||
+    circleVisibility.some((circleId) => userCircleIds.includes(circleId))
   );
 };

--- a/src/pages/commonFeed/CommonFeed.tsx
+++ b/src/pages/commonFeed/CommonFeed.tsx
@@ -255,7 +255,6 @@ const CommonFeedComponent: FC<CommonFeedProps> = (props) => {
     ) {
       feedLayoutRef?.setActiveItem({
         feedItemId: firstItem.feedItem.id,
-        circleVisibility: [],
       });
       dispatch(commonActions.setRecentStreamId(""));
     }

--- a/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
@@ -492,10 +492,7 @@ const FeedLayout: ForwardRefRenderFunction<FeedLayoutRef, FeedLayoutProps> = (
       return;
     }
 
-    setActiveChatItem({
-      feedItemId,
-      circleVisibility: [],
-    });
+    setActiveChatItem({ feedItemId });
 
     const itemExists = allFeedItems.some((item) => item.itemId === feedItemId);
 

--- a/src/pages/commonFeed/components/FeedLayout/components/DesktopProfile/DesktopProfile.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/components/DesktopProfile/DesktopProfile.tsx
@@ -46,7 +46,6 @@ const DesktopProfile: FC<DesktopProfileProps> = (props) => {
           chatChannel: chatChannel,
           discussion:
             ChatChannelToDiscussionConverter.toTargetEntity(chatChannel),
-          circleVisibility: [],
         }}
         governanceCircles={governanceCircles}
         commonId={""}

--- a/src/pages/commonFeed/components/FeedLayout/components/MobileProfile/MobileProfile.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/components/MobileProfile/MobileProfile.tsx
@@ -37,7 +37,6 @@ const MobileProfile: FC<MobileProfileProps> = (props) => {
           chatChannel: chatChannel,
           discussion:
             ChatChannelToDiscussionConverter.toTargetEntity(chatChannel),
-          circleVisibility: [],
         }}
         commonId={""}
         commonName={""}

--- a/src/pages/inbox/BaseInbox.tsx
+++ b/src/pages/inbox/BaseInbox.tsx
@@ -199,7 +199,6 @@ const InboxPage: FC<InboxPageProps> = (props) => {
       discussion: ChatChannelToDiscussionConverter.toTargetEntity(
         chatChannelItem.chatChannel,
       ),
-      circleVisibility: [],
     });
   }, [nextChatChannelItemId, feedLayoutRef]);
 

--- a/src/pages/inbox/components/ChatChannelItem/ChatChannelItem.tsx
+++ b/src/pages/inbox/components/ChatChannelItem/ChatChannelItem.tsx
@@ -47,7 +47,6 @@ export const ChatChannelItem: FC<ChatChannelFeedLayoutItemProps> = (props) => {
       feedItemId: chatChannel.id,
       discussion: ChatChannelToDiscussionConverter.toTargetEntity(chatChannel),
       chatChannel,
-      circleVisibility: [],
       lastSeenItem: chatChannelUserStatus?.lastSeenChatMessageId
         ? {
             type: LastSeenEntity.DiscussionMessage,


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] changed how we work with `recentStreamId` and now we just call `setActiveItem` of feed layout ref to select the created item. Also I removed anything related to `recentStreamId` from `FeedLayout` component
- [x] made `circleVisibility` to be nullable in `ChatItem`
