### PR TITLE
Infinite loader when clicking the Home link inside itself#2061

### DIFF
--- a/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
@@ -481,6 +481,10 @@ const FeedLayout: ForwardRefRenderFunction<FeedLayoutRef, FeedLayoutProps> = (
   ) => {
     const { commonId, messageId } = options;
 
+    if (chatItem?.feedItemId === feedItemId && !messageId) {
+      return;
+    }
+
     if (commonId && commonId !== outerCommon?.id) {
       history.push(
         getCommonPagePath(commonId, {


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/2061

### What was changed?
- Added condition for avoiding redirect for home itself
