### PR TITLE
Iphone - disable (auto-)zoom-in everywhere#2103

### DIFF
--- a/src/shared/components/Form/Formik/TextEditor/TextEditor.tsx
+++ b/src/shared/components/Form/Formik/TextEditor/TextEditor.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { useField } from "formik";
+import { useZoomDisabling } from "@/shared/hooks";
 import {
   TextEditor as BaseTextEditor,
   TextEditorProps as BaseTextEditorProps,
@@ -14,6 +15,7 @@ export interface TextEditorProps
 const TextEditor: FC<TextEditorProps> = (props) => {
   const { name, isRequired, ...restProps } = props;
   const [{ value }, { touched, error }, { setValue }] = useField(name);
+  useZoomDisabling();
   const hintToShow = restProps.hint || (isRequired ? "Required" : "");
 
   return (

--- a/src/shared/components/Form/Formik/TextField/TextField.tsx
+++ b/src/shared/components/Form/Formik/TextField/TextField.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { useField } from "formik";
+import { useZoomDisabling } from "@/shared/hooks";
 import { Input, InputProps } from "../../Input";
 
 export type TextFieldProps = InputProps & {
@@ -11,6 +12,7 @@ const TextField: FC<TextFieldProps> = (props) => {
   const { isRequired, ...restProps } = props;
   const [field, { touched, error }] = useField(restProps);
   const hintToShow = restProps.hint || (isRequired ? "Required" : "");
+  useZoomDisabling();
 
   return (
     <Input


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/2103

### What was changed?
- Added useDisablingZoom for text inputs
