### PR TITLE
Allow discussion title box to grow to 2\3 lines #2104

### DIFF
--- a/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewDiscussionCreation/components/DiscussionForm/DiscussionForm.module.scss
+++ b/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewDiscussionCreation/components/DiscussionForm/DiscussionForm.module.scss
@@ -21,3 +21,7 @@
     color: $c-neutrals-300;
   }
 }
+
+.titleTextarea {
+  height: 3.125rem !important;
+}

--- a/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewDiscussionCreation/components/DiscussionForm/DiscussionForm.tsx
+++ b/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewDiscussionCreation/components/DiscussionForm/DiscussionForm.tsx
@@ -30,6 +30,7 @@ const DiscussionForm: FC<DiscussionFormProps> = (props) => {
         styles={{
           labelWrapper: styles.textFieldLabelWrapper,
           hint: styles.textFieldHint,
+          input: { default: styles.titleTextarea },
         }}
         isTextarea
         rows={3}

--- a/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewProposalCreation/components/ProposalForm/ProposalForm.module.scss
+++ b/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewProposalCreation/components/ProposalForm/ProposalForm.module.scss
@@ -21,3 +21,7 @@
     color: $c-neutrals-300;
   }
 }
+
+.titleTextarea {
+  height: 3.125rem !important;
+}

--- a/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewProposalCreation/components/ProposalForm/ProposalForm.tsx
+++ b/src/pages/common/components/CommonTabPanels/components/FeedTab/components/NewProposalCreation/components/ProposalForm/ProposalForm.tsx
@@ -53,6 +53,7 @@ const ProposalForm: FC<ProposalFormProps> = (props) => {
         styles={{
           labelWrapper: styles.textFieldLabelWrapper,
           hint: styles.textFieldHint,
+          input: { default: styles.titleTextarea },
         }}
         isTextarea
         rows={3}


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] discussion/proposal title input can now grow vertically
