### PR TITLE
Show loader until messages are fetched #2115

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.tsx
+++ b/src/pages/common/components/ChatComponent/ChatComponent.tsx
@@ -49,7 +49,6 @@ import {
   TextEditorSize,
   removeTextEditorEmptyEndLinesValues,
   countTextEditorEmojiElements,
-  Loader,
 } from "@/shared/ui-kit";
 import { getUserName, hasPermission, isMobile } from "@/shared/utils";
 import {
@@ -651,10 +650,6 @@ export default function ChatComponent({
           type={type}
           commonMember={commonMember}
           governanceCircles={governanceCircles}
-          isCommonMemberFetched={isCommonMemberFetched}
-          isJoiningPending={false}
-          hasAccess={hasAccess}
-          isHidden={false}
           chatWrapperId={chatWrapperId}
           messages={messages}
           dateList={dateList}
@@ -669,7 +664,10 @@ export default function ChatComponent({
           onUserClick={onUserClick}
           onFeedItemClick={onFeedItemClick}
           onInternalLinkClick={onInternalLinkClick}
-          messageCount={discussion?.messageCount}
+          isEmpty={
+            discussionMessagesData.fetched &&
+            !discussionMessagesData.data?.length
+          } // not using messageCount because it includes the deleted messages as well.
         />
       </div>
       <div className={styles.bottomChatContainer}>

--- a/src/pages/common/components/ChatComponent/components/ChatContent/ChatContent.tsx
+++ b/src/pages/common/components/ChatComponent/components/ChatContent/ChatContent.tsx
@@ -11,7 +11,6 @@ import { useSelector } from "react-redux";
 import { scroller, animateScroll } from "react-scroll";
 import { v4 as uuidv4 } from "uuid";
 import { selectUser } from "@/pages/Auth/store/selectors";
-import { EmptyTabComponent } from "@/pages/OldCommon/components/CommonDetailContainer";
 import { ChatMessage, InternalLinkData } from "@/shared/components";
 import {
   ChatType,
@@ -42,10 +41,6 @@ interface ChatContentInterface {
   type: ChatType;
   commonMember: CommonMember | null;
   governanceCircles?: Circles;
-  isCommonMemberFetched: boolean;
-  isJoiningPending?: boolean;
-  hasAccess: boolean;
-  isHidden: boolean;
   chatWrapperId: string;
   messages: Record<number, DiscussionMessage[]>;
   dateList: string[];
@@ -60,7 +55,7 @@ interface ChatContentInterface {
   onUserClick?: (userId: string) => void;
   onFeedItemClick?: (feedItemId: string) => void;
   onInternalLinkClick?: (data: InternalLinkData) => void;
-  messageCount?: number;
+  isEmpty?: boolean;
 }
 
 const isToday = (someDate: Date) => {
@@ -80,10 +75,6 @@ const ChatContent: ForwardRefRenderFunction<
     type,
     commonMember,
     governanceCircles,
-    isCommonMemberFetched,
-    isJoiningPending,
-    hasAccess,
-    isHidden,
     chatWrapperId,
     messages,
     dateList,
@@ -98,7 +89,7 @@ const ChatContent: ForwardRefRenderFunction<
     onUserClick,
     onFeedItemClick,
     onInternalLinkClick,
-    messageCount,
+    isEmpty,
   },
   chatContentRef,
 ) => {
@@ -195,23 +186,6 @@ const ChatContent: ForwardRefRenderFunction<
     [scrollToContainerBottom],
   );
 
-  if (!hasAccess || isHidden) {
-    return (
-      <EmptyTabComponent
-        currentTab="messages"
-        message={
-          isHidden
-            ? "This discussion was hidden due to inappropriate content"
-            : "This content is private and visible only to members of the common in specific circles."
-        }
-        title=""
-        isCommonMember={Boolean(commonMember)}
-        isCommonMemberFetched={isCommonMemberFetched}
-        isJoiningPending={isJoiningPending}
-      />
-    );
-  }
-
   if (isLoading) {
     return (
       <div className={styles.loaderContainer}>
@@ -301,7 +275,7 @@ const ChatContent: ForwardRefRenderFunction<
           </ul>
         );
       })}
-      {!isLoading && messageCount === 0 && (
+      {!isLoading && isEmpty && (
         <p className={styles.noMessagesText}>
           There are no messages here yet.
           <br />


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Show loader until messages are loaded. Use `discussionMessagesData` to determine if the chat is empty. Not using `messageCount` since the BE counts also deleted messages in this count.
- [x] Eliminate the check of `hasAccess` or `isHidden` because the check is already done before and the item won't appear to the user in case he doesn't have an access or if it's hidden.
