### PR TITLE
Add action menu for dms with mark as read\unread functionality #2048

### DIFF
--- a/src/pages/inbox/components/ChatChannelItem/ChatChannelItem.tsx
+++ b/src/pages/inbox/components/ChatChannelItem/ChatChannelItem.tsx
@@ -12,23 +12,20 @@ import { ChatChannel } from "@/shared/models";
 import { getUserName } from "@/shared/utils";
 import { inboxActions } from "@/store/states";
 import { FeedItemBaseContent } from "../FeedItemBaseContent";
-import { useChatChannelSubscription } from "./hooks";
+import { useChatChannelSubscription, useMenuItems } from "./hooks";
 import { getLastMessage } from "./utils";
 
 export const ChatChannelItem: FC<ChatChannelFeedLayoutItemProps> = (props) => {
   const { chatChannel, isActive, onActiveItemDataChange } = props;
   const dispatch = useDispatch();
   const isTabletView = useIsTabletView();
-  const {
-    fetchUser: fetchDMUser,
-    data: dmUser,
-    fetched: isDMUserFetched,
-  } = useUserById();
+  const { fetchUser: fetchDMUser, data: dmUser } = useUserById();
   const {
     data: chatChannelUserStatus,
     fetched: isChatChannelUserStatusFetched,
     fetchChatChannelUserStatus,
   } = useChatChannelUserStatus();
+  const menuItems = useMenuItems({ chatChannelUserStatus });
   const { setChatItem, feedItemIdForAutoChatOpen, shouldAllowChatAutoOpen } =
     useChatContext();
   const user = useSelector(selectUser());
@@ -126,7 +123,8 @@ export const ChatChannelItem: FC<ChatChannelFeedLayoutItemProps> = (props) => {
       lastMessage={getLastMessage(chatChannel.lastMessage)}
       canBeExpanded={false}
       onClick={handleOpenChat}
-      menuItems={[]}
+      menuItems={menuItems}
+      seen={chatChannelUserStatus?.seen}
       seenOnce={chatChannelUserStatus?.seenOnce}
       ownerId={userId}
       renderImage={renderImage}

--- a/src/pages/inbox/components/ChatChannelItem/constants/chatChannelMenuItems.ts
+++ b/src/pages/inbox/components/ChatChannelItem/constants/chatChannelMenuItems.ts
@@ -1,0 +1,4 @@
+export enum ChatChannelMenuItem {
+  MarkUnread = "markUnread",
+  MarkRead = "markRead",
+}

--- a/src/pages/inbox/components/ChatChannelItem/constants/index.ts
+++ b/src/pages/inbox/components/ChatChannelItem/constants/index.ts
@@ -1,0 +1,1 @@
+export * from "./chatChannelMenuItems";

--- a/src/pages/inbox/components/ChatChannelItem/hooks/index.ts
+++ b/src/pages/inbox/components/ChatChannelItem/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useChatChannelSubscription";
+export * from "./useMenuItems";

--- a/src/pages/inbox/components/ChatChannelItem/hooks/useMenuItems.tsx
+++ b/src/pages/inbox/components/ChatChannelItem/hooks/useMenuItems.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { ChatService } from "@/services";
+import { Message3Icon } from "@/shared/icons";
+import { ContextMenuItem as Item } from "@/shared/interfaces";
+import { ChatChannelMenuItem } from "../constants";
+import { getAllowedItems, Options as GetAllowedItemsOptions } from "../utils";
+
+export const useMenuItems = (options: GetAllowedItemsOptions): Item[] => {
+  const { chatChannelUserStatus } = options;
+  const items: Item[] = [
+    {
+      id: ChatChannelMenuItem.MarkUnread,
+      text: "Mark as unread",
+      onClick: async () => {
+        if (!chatChannelUserStatus) {
+          return;
+        }
+
+        await ChatService.markChatChannelAsUnseen(
+          chatChannelUserStatus.chatChannelId,
+        );
+      },
+      icon: <Message3Icon />,
+    },
+    {
+      id: ChatChannelMenuItem.MarkRead,
+      text: "Mark as read",
+      onClick: async () => {
+        if (!chatChannelUserStatus) {
+          return;
+        }
+
+        await ChatService.markChatChannelAsSeen(
+          chatChannelUserStatus.chatChannelId,
+        );
+      },
+      icon: <Message3Icon />,
+    },
+  ];
+
+  return getAllowedItems(items, options);
+};

--- a/src/pages/inbox/components/ChatChannelItem/utils/getAllowedItems.ts
+++ b/src/pages/inbox/components/ChatChannelItem/utils/getAllowedItems.ts
@@ -1,0 +1,20 @@
+import { ContextMenuItem as Item } from "@/shared/interfaces";
+import { ChatChannelUserStatus } from "@/shared/models";
+import { ChatChannelMenuItem } from "../constants";
+
+export interface Options {
+  chatChannelUserStatus: ChatChannelUserStatus | null;
+}
+
+const MENU_ITEM_TO_CHECK_FUNCTION_MAP: Record<
+  ChatChannelMenuItem,
+  (options: Options) => boolean
+> = {
+  [ChatChannelMenuItem.MarkUnread]: ({ chatChannelUserStatus }) =>
+    Boolean(chatChannelUserStatus?.seen),
+  [ChatChannelMenuItem.MarkRead]: ({ chatChannelUserStatus }) =>
+    Boolean(chatChannelUserStatus && !chatChannelUserStatus.seen),
+};
+
+export const getAllowedItems = (items: Item[], options: Options): Item[] =>
+  items.filter(({ id }) => MENU_ITEM_TO_CHECK_FUNCTION_MAP[id](options));

--- a/src/pages/inbox/components/ChatChannelItem/utils/index.ts
+++ b/src/pages/inbox/components/ChatChannelItem/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./getLastMessage";
+export * from "./getAllowedItems";

--- a/src/services/Chat.ts
+++ b/src/services/Chat.ts
@@ -192,6 +192,18 @@ class ChatService {
     );
   };
 
+  public markChatChannelAsUnseen = async (
+    chatChannelId: string,
+    options: { cancelToken?: CancelToken } = {},
+  ): Promise<void> => {
+    const { cancelToken } = options;
+    await Api.post(
+      ApiEndpoint.MarkChatChannelAsUnseen(chatChannelId),
+      undefined,
+      { cancelToken },
+    );
+  };
+
   public markChatMessageAsSeen = async (
     chatMessageId: string,
     options: { cancelToken?: CancelToken } = {},

--- a/src/shared/constants/endpoint.ts
+++ b/src/shared/constants/endpoint.ts
@@ -57,6 +57,8 @@ export const ApiEndpoint = {
     `/chat/message/${chatMessageId}`,
   MarkChatChannelAsSeen: (channelId: string) =>
     `/chat/channel/${channelId}/seen`,
+  MarkChatChannelAsUnseen: (channelId: string) =>
+    `/chat/channel/${channelId}/unseen`,
   MarkChatMessageAsSeen: (chatMessageId: string) =>
     `/chat/message/${chatMessageId}/seen`,
 };

--- a/src/shared/models/ChatChannelUserStatus.ts
+++ b/src/shared/models/ChatChannelUserStatus.ts
@@ -8,4 +8,5 @@ export interface ChatChannelUserStatus extends BaseEntity {
   notSeenCount: number;
   seenOnce?: boolean;
   seenAt?: Timestamp;
+  seen: boolean;
 }


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Added an actions menu with `mark as read/unread` items to the DMs
