### PR TITLE
Remove the "there are no messages" when there are messages in dm #2173

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.tsx
+++ b/src/pages/common/components/ChatComponent/ChatComponent.tsx
@@ -688,7 +688,7 @@ export default function ChatComponent({
           isEmpty={
             discussionMessagesData.fetched &&
             !discussionMessagesData.data?.length && // for non direct messages chats. not using messageCount because it includes the deleted messages as well.
-            Object.keys(messages).length === 0 // for direct messages chats
+            Object.keys(discussionMessages).length === 0 // for direct messages chats
           }
         />
       </div>


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] dm: don't show 'no messages' while there are messges in the chat
