### PR TITLE
Breadcrumb & Navbar: Show the active item on top #2056

### DIFF
--- a/src/shared/layouts/MultipleSpacesLayout/components/Header/components/Breadcrumbs/components/FeedItemBreadcrumbs/utils/getBreadcrumbsData.ts
+++ b/src/shared/layouts/MultipleSpacesLayout/components/Header/components/Breadcrumbs/components/FeedItemBreadcrumbs/utils/getBreadcrumbsData.ts
@@ -87,7 +87,9 @@ export const getBreadcrumbsData = (
 
   data.unshift({
     activeCommonId: activeCommonIdInParentCommonProjects,
-    items: mainLevelCommons,
+    items: mainLevelCommons.sort(
+      getSortFn(activeCommonIdInParentCommonProjects),
+    ),
   });
 
   return {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Added sorting of root breadcrumb items to display the active common on top
