### PR TITLE
change default settings for notification and emails #2202

### DIFF
--- a/src/pages/settings/components/Settings/components/SettingsForm/SettingsForm.tsx
+++ b/src/pages/settings/components/Settings/components/SettingsForm/SettingsForm.tsx
@@ -41,9 +41,9 @@ const getInitialValues = (
   > | null,
 ): FormValues => ({
   pushNotificationPreference:
-    data?.pushNotificationPreference ?? UserPushNotificationPreference.None,
+    data?.pushNotificationPreference ?? UserPushNotificationPreference.All,
   emailNotificationPreference:
-    data?.emailNotificationPreference ?? UserEmailNotificationPreference.None,
+    data?.emailNotificationPreference ?? UserEmailNotificationPreference.All,
 });
 
 const SettingsForm: FC<SettingsFormProps> = (props) => {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] changed default setting to `all` value
