### PR TITLE
Update space items counters without refresh #2190

### DIFF
--- a/src/pages/common/components/FeedItem/FeedItem.tsx
+++ b/src/pages/common/components/FeedItem/FeedItem.tsx
@@ -15,7 +15,6 @@ import { DiscussionFeedCard } from "../DiscussionFeedCard";
 import { ProposalFeedCard } from "../ProposalFeedCard";
 import { ProjectFeedItem } from "./components";
 import { useFeedItemContext } from "./context";
-import { useFeedItemCounters } from "./hooks";
 import { FeedItemRef } from "./types";
 
 interface FeedItemProps {
@@ -68,8 +67,6 @@ const FeedItem = forwardRef<FeedItemRef, FeedItemProps>((props, ref) => {
   const { onFeedItemUpdate, getLastMessage, getNonAllowedItems, onUserSelect } =
     useFeedItemContext();
   useFeedItemSubscription(item.id, commonId, onFeedItemUpdate);
-  const { projectUnreadStreamsCount, projectUnreadMessages } =
-    useFeedItemCounters(item.id, commonId);
 
   if (
     shouldCheckItemVisibility &&
@@ -118,14 +115,7 @@ const FeedItem = forwardRef<FeedItemRef, FeedItemProps>((props, ref) => {
   }
 
   if (item.data.type === CommonFeedType.Project) {
-    return (
-      <ProjectFeedItem
-        item={item}
-        isMobileVersion={isMobileVersion}
-        unreadStreamsCount={projectUnreadStreamsCount}
-        unreadMessages={projectUnreadMessages}
-      />
-    );
+    return <ProjectFeedItem item={item} isMobileVersion={isMobileVersion} />;
   }
 
   return null;

--- a/src/pages/common/components/FeedItem/components/ProjectFeedItem/ProjectFeedItem.tsx
+++ b/src/pages/common/components/FeedItem/components/ProjectFeedItem/ProjectFeedItem.tsx
@@ -8,28 +8,29 @@ import { OpenIcon } from "@/shared/icons";
 import { CommonFeed } from "@/shared/models";
 import { CommonAvatar, parseStringToTextEditorValue } from "@/shared/ui-kit";
 import { checkIsProject } from "@/shared/utils";
+import { useFeedItemCounters } from "../../hooks";
 import styles from "./ProjectFeedItem.module.scss";
 
 interface ProjectFeedItemProps {
   item: CommonFeed;
   isMobileVersion: boolean;
-  unreadStreamsCount?: number;
-  unreadMessages?: number;
 }
 
 export const ProjectFeedItem: FC<ProjectFeedItemProps> = (props) => {
-  const { item, isMobileVersion, unreadStreamsCount, unreadMessages } = props;
+  const { item, isMobileVersion } = props;
   const history = useHistory();
   const { getCommonPagePath } = useRoutesContext();
   const { renderFeedItemBaseContent } = useFeedItemContext();
   const { data: common, fetched: isCommonFetched, fetchCommon } = useCommon();
+  const {
+    projectUnreadStreamsCount: unreadStreamsCount,
+    projectUnreadMessages: unreadMessages,
+  } = useFeedItemCounters(item.id, common?.directParent?.commonId);
   const commonId = item.data.id;
   const lastMessage = parseStringToTextEditorValue(
-    Number.isInteger(unreadStreamsCount)
-      ? `${unreadStreamsCount} updated stream${
-          unreadStreamsCount === 1 ? "" : "s"
-        }`
-      : undefined,
+    `${unreadStreamsCount ?? 0} updated stream${
+      unreadStreamsCount === 1 ? "" : "s"
+    }`,
   );
   const isProject = checkIsProject(common);
   const titleEl = (


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Show project feed item counter even if nothing has been updated
- [x] Moved the usage of the `useFeedItemCounters` hook to the `ProjectFeedItem` component
