### PR TITLE
Hebrew input chat: can't re-click on input #2223

### DIFF
--- a/src/shared/ui-kit/TextEditor/components/EmojiPicker/EmojiPicker.module.scss
+++ b/src/shared/ui-kit/TextEditor/components/EmojiPicker/EmojiPicker.module.scss
@@ -8,6 +8,7 @@ $phone-breakpoint: 415px;
   bottom: 1.5625rem;
   right: 0.5625rem;
   transform: translateY(50%);
+  width: fit-content;
 }
 
 .containerRtl {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fix: emoji container in chat input is full width blocking re-click on input.
