### PR TITLE
App crashes in some commons when trying to load members #2276

### DIFF
--- a/src/pages/OldCommon/components/CommonDetailContainer/MembersComponent/CommonMemberComponent.tsx
+++ b/src/pages/OldCommon/components/CommonDetailContainer/MembersComponent/CommonMemberComponent.tsx
@@ -79,7 +79,7 @@ const CommonMember: FC<CommonMemberProps> = ({
     circlesWithHighestTier[circlesWithHighestTier.length - 1];
 
   governanceCircles.forEach((circle) => {
-    if (!highestMemberCircle.hierarchy) {
+    if (!highestMemberCircle?.hierarchy) {
       return;
     }
     if (!circle.hierarchy) {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fix: app crashes in some commons when trying to load members.
Reproduce in this common for example: https://web-dev.common.io/commons/4c87126a-d764-42c5-90dc-723431fa5a46
