### PR TITLE
Iphones - Discussion messages appear only after touching the screen #2101

### DIFF
--- a/src/pages/common/components/ChatComponent/components/ChatContent/ChatContent.tsx
+++ b/src/pages/common/components/ChatComponent/components/ChatContent/ChatContent.tsx
@@ -100,10 +100,10 @@ const ChatContent: ForwardRefRenderFunction<
   const forceUpdate = useForceUpdate();
 
   useEffect(() => {
-    if (messages) {
+    if (messages || dateList) {
       forceUpdate();
     }
-  }, [messages]);
+  }, [messages, dateList]);
 
   const [highlightedMessageId, setHighlightedMessageId] = useState(
     () => (typeof messageIdParam === "string" && messageIdParam) || null,


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [ ] iPhones - sometimes discussion messages appear only after touching the screen.
