### PR TITLE
Attached filename in a message and in a reply is different #2284

### DIFF
--- a/src/pages/common/components/ChatComponent/components/MessageReply/MessageReply.tsx
+++ b/src/pages/common/components/ChatComponent/components/MessageReply/MessageReply.tsx
@@ -62,7 +62,7 @@ const MessageReply: React.FC<MessageReplyProps> = ({ users }) => {
             {file && (
               <FilePreview
                 containerClassName={styles.fileContainer}
-                name={file.title}
+                name={file.name ?? file.title}
                 src={file.value}
                 isPreview
                 size={24}
@@ -77,7 +77,7 @@ const MessageReply: React.FC<MessageReplyProps> = ({ users }) => {
               {file ? (
                 <>
                   <p className={styles.text}>
-                    {getFileName(file.title, FILE_NAME_LIMIT)}
+                    {getFileName(file.name ?? file.title, FILE_NAME_LIMIT)}
                   </p>
                   {file.size && (
                     <p className={styles.fileSize}>{convertBytes(file.size)}</p>

--- a/src/shared/components/Chat/ChatMessage/ChatMessage.tsx
+++ b/src/shared/components/Chat/ChatMessage/ChatMessage.tsx
@@ -309,7 +309,7 @@ export default function ChatMessage({
             {file ? (
               <>
                 <p className={styles.fileTitle}>
-                  {getFileName(file.title, FILE_NAME_LIMIT)}
+                  {getFileName(file.name ?? file.title, FILE_NAME_LIMIT)}
                 </p>
                 {file.size && (
                   <p className={styles.fileSize}>{convertBytes(file.size)}</p>


### PR DESCRIPTION
https://github.com/daostack/common-web/issues/2284

### What was changed?
- Added name field usage in reply messages
