### PR TITLE
Allow using same space name if parent common is different #2393

### DIFF
--- a/src/pages/commonCreation/components/ProjectCreation/components/ProjectCreationForm/ProjectCreationForm.tsx
+++ b/src/pages/commonCreation/components/ProjectCreation/components/ProjectCreationForm/ProjectCreationForm.tsx
@@ -130,7 +130,11 @@ const ProjectCreationForm: FC<ProjectCreationFormProps> = (props) => {
   );
   const projectId = initialCommon?.id || project?.id;
 
+  /**
+   * Existing projects names under the same direct parent only.
+   */
   const existingProjectsNames = projects
+    .filter((project) => project.directParent?.commonId === parentCommonId)
     .map((project) => project?.name)
     .filter((spaceName) => spaceName !== initialValues?.spaceName);
 


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Allow using same space name if parent common is different.
