### PR TITLE
Update default Email notification settings FE #2428

### DIFF
--- a/src/pages/settings/components/Settings/components/SettingsForm/SettingsForm.tsx
+++ b/src/pages/settings/components/Settings/components/SettingsForm/SettingsForm.tsx
@@ -43,7 +43,8 @@ const getInitialValues = (
   pushNotificationPreference:
     data?.pushNotificationPreference ?? UserPushNotificationPreference.All,
   emailNotificationPreference:
-    data?.emailNotificationPreference ?? UserEmailNotificationPreference.All,
+    data?.emailNotificationPreference ??
+    UserEmailNotificationPreference.Important,
 });
 
 const SettingsForm: FC<SettingsFormProps> = (props) => {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] update default email notifications prefernce if emailNotificationPreference is absence
