### PR TITLE
Add card header to expanded Home cards #2448

### DIFF
--- a/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
+++ b/src/pages/common/components/DiscussionFeedCard/DiscussionFeedCard.tsx
@@ -298,7 +298,6 @@ const DiscussionFeedCard = forwardRef<FeedItemRef, DiscussionFeedCardProps>(
             onUserSelect={
               onUserSelect && (() => onUserSelect(item.userId, commonId))
             }
-            isHome={isHome}
           />
           <FeedCardContent
             description={isHome ? common?.description : discussion?.message}

--- a/src/pages/common/components/FeedCard/components/FeedCardHeader/FeedCardHeader.tsx
+++ b/src/pages/common/components/FeedCard/components/FeedCardHeader/FeedCardHeader.tsx
@@ -20,7 +20,6 @@ export interface FeedCardHeaderProps {
   userId?: string;
   directParent?: DirectParent | null;
   onUserSelect?: () => void;
-  isHome?: boolean;
 }
 
 export const FeedCardHeader: React.FC<FeedCardHeaderProps> = (props) => {
@@ -36,7 +35,6 @@ export const FeedCardHeader: React.FC<FeedCardHeaderProps> = (props) => {
     userId,
     directParent,
     onUserSelect,
-    isHome,
   } = props;
   const {
     isShowing: isShowingUserProfile,
@@ -81,7 +79,7 @@ export const FeedCardHeader: React.FC<FeedCardHeaderProps> = (props) => {
             </p>
           )}
         </div>
-        {!isHome && !isMobileVersion && menuItems.length > 0 && (
+        {!isMobileVersion && menuItems.length > 0 && (
           <DesktopMenu
             triggerEl={<MenuButton className={styles.threeDotMenu} />}
             items={menuItems}


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Add card header to expended home cards.
