### PR TITLE
Discussion info with link only isn't shown #2466

### DIFF
--- a/src/pages/common/components/FeedCard/components/FeedGeneralInfo/FeedGeneralInfo.tsx
+++ b/src/pages/common/components/FeedCard/components/FeedGeneralInfo/FeedGeneralInfo.tsx
@@ -24,14 +24,11 @@ export const FeedGeneralInfo: React.FC<FeedGeneralInfoProps> = (props) => {
     isFullTextShowing,
     toggleFullText,
   } = useFullText<HTMLElement>();
-  console.log(description);
   const parsedDescription = useMemo(
     () => parseStringToTextEditorValue(description),
     [description],
   );
-  console.log(parsedDescription);
   const isDescriptionEmpty = checkIsTextEditorValueEmpty(parsedDescription);
-  console.log(isDescriptionEmpty);
   const shouldDisplaySeeMoreButton =
     (shouldShowFullContent || !isFullTextShowing) && !isDescriptionEmpty;
 


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fix: discussion info not showing when has link only
