### PR TITLE
Incorrect handling of unfollowed (cached) inbox items #2473

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.tsx
+++ b/src/pages/common/components/ChatComponent/ChatComponent.tsx
@@ -565,7 +565,7 @@ export default function ChatComponent({
       markChatMessageItemAsSeen({
         chatChannelId: feedItemId,
       });
-    } else {
+    } else if (commonId) {
       markDiscussionMessageItemAsSeen({
         feedObjectId: feedItemId,
         commonId,


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] fixed marking of feed item as seen when `commonId` was `""`
