### PR TITLE
Tooltips doesn't appear #2481

### DIFF
--- a/src/shared/ui-kit/Tooltip/hooks/useTooltip.ts
+++ b/src/shared/ui-kit/Tooltip/hooks/useTooltip.ts
@@ -21,7 +21,7 @@ export const useTooltip = (options: TooltipOptions = {}) => {
     placement = "top",
     open: controlledOpen,
     onOpenChange: setControlledOpen,
-    shouldOpenOnHover = false,
+    shouldOpenOnHover,
   } = options;
   const [uncontrolledOpen, setUncontrolledOpen] = useState(initialOpen);
   const arrowRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] Got rid of the default value for the `shouldOpenOnHover` property of a tooltip
