### PR TITLE
when joining a common i cant enter a link #2498

### DIFF
--- a/src/shared/constants/shared.tsx
+++ b/src/shared/constants/shared.tsx
@@ -60,7 +60,7 @@ export const MAX_LINK_TITLE_LENGTH = 30;
 export const NUMBERS_ONLY_REGEXP = /^[0-9]*$/;
 
 export const URL_REGEXP =
-  /^(http:\/\/|https:\/\/)[\w.-]+\.[\w]{2,}(\/[\w/_.]*)*\/?$/;
+  /^(http:\/\/|https:\/\/)[\w.-]+\.[\w]{2,}(\/[\w/?&=._-]*)*\/?$/;
 export const NAME_REGEXP = /^[aA-zZ\s]+$/;
 
 export enum ShareViewType {


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] correct url regex that includes queary params and must start with `http://` or `https://`. Related to https://github.com/daostack/common-web/issues/2340
