### PR TITLE
Chat title shouldn’t disappear upon keyboard slide-up on iPhone #2503

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.module.scss
+++ b/src/pages/common/components/ChatComponent/ChatComponent.module.scss
@@ -137,3 +137,11 @@ $phone-breakpoint: 415px;
 .multipleEmojiText {
   font-size: $large;
 }
+
+.header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  background-color: red;
+  z-index: 99999;
+}

--- a/src/pages/common/components/ChatComponent/ChatComponent.tsx
+++ b/src/pages/common/components/ChatComponent/ChatComponent.tsx
@@ -156,6 +156,7 @@ export default function ChatComponent({
   const userId = user?.uid;
   const discussionId = discussion?.id || "";
   const isChatChannel = Boolean(chatChannel);
+  const [showHeader, setShowHeader] = useState(false);
 
   const hasPermissionToHide =
     commonMember && governanceCircles
@@ -694,6 +695,12 @@ export default function ChatComponent({
             }),
           }}
           value={message}
+          onFocus={() => {
+            setShowHeader(true);
+          }}
+          onBlur={() => {
+            setShowHeader(false);
+          }}
           onChange={setMessage}
           placeholder="Message"
           onKeyDown={onEnterKeyDown}
@@ -753,6 +760,7 @@ export default function ChatComponent({
         ref={chatContainerRef}
       >
         <ChatContentContext.Provider value={chatContentContextValue}>
+          {showHeader && <div className={styles.header}>HEADER</div>}
           <ChatContent
             ref={chatContentRef}
             discussionMessages={discussionMessagesData.data}

--- a/src/shared/ui-kit/TextEditor/BaseTextEditor.tsx
+++ b/src/shared/ui-kit/TextEditor/BaseTextEditor.tsx
@@ -61,6 +61,7 @@ export interface TextEditorProps {
   value: TextEditorValue;
   onChange?: (value: TextEditorValue) => void;
   onBlur?: FocusEventHandler;
+  onFocus?: FocusEventHandler;
   size?: TextEditorSize;
   disabled?: boolean;
   onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void;
@@ -95,6 +96,7 @@ const BaseTextEditor: FC<TextEditorProps> = (props) => {
     value,
     onChange,
     onBlur,
+    onFocus,
     onKeyDown,
     size,
     placeholder,
@@ -319,6 +321,7 @@ const BaseTextEditor: FC<TextEditorProps> = (props) => {
           readOnly={false}
           disabled={disabled}
           onBlur={onBlur}
+          onFocus={onFocus}
           onKeyDown={handleKeyDown}
           scrollSelectionIntoView={scrollSelectionIntoView}
           elementStyles={elementStyles}

--- a/src/shared/ui-kit/TextEditor/components/Editor/Editor.tsx
+++ b/src/shared/ui-kit/TextEditor/components/Editor/Editor.tsx
@@ -24,6 +24,7 @@ interface EditorProps {
   readOnly?: boolean;
   disabled?: boolean;
   onBlur?: FocusEventHandler;
+  onFocus?: FocusEventHandler;
   elementStyles?: EditorElementStyles;
   onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void;
   scrollSelectionIntoView?: (editor: ReactEditor, domRange: DOMRange) => void;
@@ -37,6 +38,7 @@ const Editor: FC<EditorProps> = (props) => {
     readOnly = false,
     disabled = false,
     onBlur,
+    onFocus,
     onKeyDown,
     scrollSelectionIntoView,
   } = props;
@@ -80,6 +82,7 @@ const Editor: FC<EditorProps> = (props) => {
       spellCheck
       readOnly={readOnly || disabled}
       onBlur={onBlur}
+      onFocus={onFocus}
       onKeyDown={handleKeyDown}
       scrollSelectionIntoView={scrollSelectionIntoView}
     />


### PR DESCRIPTION
- [ ] PR title equals to the ticket name
- [ ] I added the ticket to the `Development` section of this PR.

### What was changed?
- [ ] 
