### PR TITLE
Emoji picker button location in rtl

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.module.scss
+++ b/src/pages/common/components/ChatComponent/ChatComponent.module.scss
@@ -68,14 +68,14 @@
   flex-direction: column;
   justify-content: center;
   word-break: break-word;
-  padding: 0.125rem 1.75rem 0.125rem 0.75rem;
+  padding: 0.125rem 2.5rem 0.125rem 0.75rem;
   margin: 0.3rem 0;
   overflow-x: hidden;
   min-height: 2.625rem !important;
 }
 
 .messageInputRtl {
-  padding: 0.125rem 0.25rem 0.125rem 1.75rem;
+  padding: 0.125rem 2.5rem 0.125rem 0.75rem;
 }
 
 .messageInputEmpty {

--- a/src/shared/ui-kit/TextEditor/components/EmojiPicker/EmojiPicker.module.scss
+++ b/src/shared/ui-kit/TextEditor/components/EmojiPicker/EmojiPicker.module.scss
@@ -11,10 +11,6 @@ $phone-breakpoint: 415px;
   width: fit-content;
 }
 
-.containerRtl {
-  left: 0.5625rem;
-}
-
 .pickerContainer {
   position: absolute;
   bottom: 3.25rem;

--- a/src/shared/ui-kit/TextEditor/components/EmojiPicker/EmojiPicker.tsx
+++ b/src/shared/ui-kit/TextEditor/components/EmojiPicker/EmojiPicker.tsx
@@ -54,9 +54,7 @@ const EmojiPicker: FC<EmojiPickerProps> = (props) => {
   return (
     <div
       ref={wrapperRef}
-      className={classNames(styles.container, containerClassName, {
-        [styles.containerRtl]: isRtl,
-      })}
+      className={classNames(styles.container, containerClassName)}
     >
       <ButtonIcon onClick={handleOpenPicker}>
         <EmojiIcon />


### PR DESCRIPTION
resolves: https://www.notion.so/daostack/Leave-emoji-icon-in-place-for-RTL-text-90c962bd925345a38bc1b78c5ee4b46d

### What was changed?
- [x] emoji picker button location in rtl stays the same as in ltr
