### PR TITLE
group chat: show last message username

### DIFF
--- a/src/pages/inbox/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
+++ b/src/pages/inbox/components/FeedItemBaseContent/FeedItemBaseContent.module.scss
@@ -91,7 +91,6 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  font-size: $xsmall;
 }
 
 .text {


### PR DESCRIPTION
resolves: https://www.notion.so/daostack/Display-sender-name-in-group-messages-last-message-preview-f9d7c3111a9c4852b7e8d3009611f893

### What was changed?
- [x] group chat: show last message preview username
