### PR TITLE
Chat: paste files without override existing

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.tsx
+++ b/src/pages/common/components/ChatComponent/ChatComponent.tsx
@@ -352,14 +352,8 @@ export default function ChatComponent({
    * Since the component's state is stale while executing the "paste" event listener callback,
    * we need to save it in a ref and update it so the fresh data is available in the callback.
    */
-  useEffect(() => {
-    setCurrentFilesPreviewRef(currentFilesPreview);
-  }, [currentFilesPreview]);
-
   const currentFilesPreviewRef = useRef(currentFilesPreview);
-  const setCurrentFilesPreviewRef = (currentFiles: FileInfo[] | null) => {
-    currentFilesPreviewRef.current = currentFiles;
-  };
+  currentFilesPreviewRef.current = currentFilesPreview;
 
   const uploadFiles = (
     event: ChangeEvent<HTMLInputElement> | ClipboardEvent,


### PR DESCRIPTION
resolves: https://www.notion.so/daostack/Pasting-multiple-images-aefdd4d2b1fb402b9040664aa6dea88f

### What was changed?
- [x] Chat: paste files without override existing
