### PR TITLE
"&" in the title for my chat with myself #2548

### DIFF
--- a/src/pages/inbox/components/ChatChannelItem/ChatChannelItem.tsx
+++ b/src/pages/inbox/components/ChatChannelItem/ChatChannelItem.tsx
@@ -38,8 +38,12 @@ export const ChatChannelItem: FC<ChatChannelFeedLayoutItemProps> = (props) => {
   const isGroupMessage = chatChannel.participants.length > 2;
   const dmUserIds = useMemo(
     () =>
-      chatChannel.participants.filter((participant) => participant !== userId),
-    [],
+      chatChannel.participants.length === 1
+        ? chatChannel.participants
+        : chatChannel.participants.filter(
+            (participant) => participant !== userId,
+          ),
+    [chatChannel.participants],
   );
 
   const dmUsersNames = dmUsers?.map((user) => getUserName(user));


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] where there is only 1 participant in the chat channel item we use it in the `dmUserIds`, otherwise previous logic is used
