### PR TITLE
Avoid calling "mark feed item as read" for items which are read #2556

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.tsx
+++ b/src/pages/common/components/ChatComponent/ChatComponent.tsx
@@ -91,6 +91,7 @@ interface ChatComponentInterface {
   feedItemId: string;
   isAuthorized?: boolean;
   isHidden: boolean;
+  seenOnce?: boolean;
   onMessagesAmountChange?: (newMessagesAmount: number) => void;
   directParent?: DirectParent | null;
   renderChatInput?: () => ReactNode;
@@ -136,6 +137,7 @@ export default function ChatComponent({
   feedItemId,
   isAuthorized,
   isHidden = false,
+  seenOnce = false,
   onMessagesAmountChange,
   directParent,
   renderChatInput: renderChatInputOuter,
@@ -581,6 +583,10 @@ export default function ChatComponent({
   );
 
   useEffect(() => {
+    if (seenOnce) {
+      return;
+    }
+
     if (isChatChannel) {
       markChatMessageItemAsSeen({
         chatChannelId: feedItemId,

--- a/src/pages/commonFeed/components/FeedLayout/components/DesktopChat/DesktopChat.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/components/DesktopChat/DesktopChat.tsx
@@ -123,6 +123,7 @@ const DesktopChat: FC<ChatProps> = (props) => {
         hasAccess={hasAccessToChat}
         lastSeenItem={chatItem.lastSeenItem}
         isHidden={false}
+        seenOnce={chatItem.seenOnce}
         isAuthorized={Boolean(user)}
         onMessagesAmountChange={onMessagesAmountChange}
         directParent={directParent}

--- a/src/pages/commonFeed/components/FeedLayout/components/MobileChat/MobileChat.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/components/MobileChat/MobileChat.tsx
@@ -155,6 +155,7 @@ const MobileChat: FC<ChatProps> = (props) => {
             }
             hasAccess={hasAccessToChat}
             isHidden={false}
+            seenOnce={chatItem.seenOnce}
             commonId={commonId}
             discussion={chatItem.discussion}
             chatChannel={chatItem.chatChannel}


### PR DESCRIPTION
- [x] PR title equals to the ticket name
- [x] I added the ticket to the `Development` section of this PR.

### What was changed?
- [x] avoid initial marking of item as read if it was seen once
