### PR TITLE
Stream info text always aligned to center

### DIFF
--- a/src/pages/commonFeed/components/FeedLayout/FeedLayout.module.scss
+++ b/src/pages/commonFeed/components/FeedLayout/FeedLayout.module.scss
@@ -64,7 +64,6 @@
 }
 
 .pullToRefresh {
-  text-align: center;
   color: var(--primary-text);
 
   @include tablet {


### PR DESCRIPTION
[Ticket](https://www.notion.so/daostack/Stream-info-text-always-aligned-to-center-31eeed13572f453480f5aa7be7b0a131?pvs=4)

- [x] PR title equals to the ticket name

### What was changed?
- [x] removed center alignment from `pullToRefresh` class
