### PR TITLE
Fix origin (linked) message color in dark mode

### DIFF
--- a/src/shared/components/Chat/ChatMessage/ChatMessage.module.scss
+++ b/src/shared/components/Chat/ChatMessage/ChatMessage.module.scss
@@ -1,4 +1,5 @@
-@import "../../../../constants.scss";
+@import "../../../../constants";
+@import "../../../../styles/mixins";
 @import "../../../../styles/sizes";
 
 .message {
@@ -260,6 +261,13 @@
   background-color: $c-pink-active-btn;
 }
 
+@include darkTheme {
+  .highlighted {
+    border: 0;
+    background-color: var(--quaternary-fill);
+  }
+}
+
 .highlightedOwn {
   animation: highlightedOwn 10s forwards;
   border: 0.094rem solid $dark-yellow;
@@ -270,6 +278,15 @@
   100% {
     border-color: transparent;
     background-color: $c-light-gray;
+  }
+}
+
+@include darkTheme {
+  @keyframes highlighted {
+    100% {
+      border-color: transparent;
+      background-color: var(--secondary-background);
+    }
   }
 }
 

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -15,3 +15,15 @@
     margin: $gap 0 0 $gap;
   }
 }
+
+@mixin lightTheme {
+  :root[data-theme="light"] {
+    @content;
+  }
+}
+
+@mixin darkTheme {
+  :root[data-theme="dark"] {
+    @content;
+  }
+}


### PR DESCRIPTION
[Ticket](https://www.notion.so/daostack/Fix-origin-linked-message-color-in-dark-mode-ef9e563af2cd44d9b433bb8b46f33d8b?pvs=4)

- [x] PR title equals to the ticket name

### What was changed?
- [x] created scss mixins for light and dark themes
- [x] fixed highlighted chat message color for dark theme
