### PR TITLE
Chat input: remove bottom border

### DIFF
--- a/src/pages/common/components/ChatComponent/ChatComponent.module.scss
+++ b/src/pages/common/components/ChatComponent/ChatComponent.module.scss
@@ -38,9 +38,7 @@
   flex-shrink: 0;
   padding: 0 1.125rem;
   background-color: var(--primary-background);
-  border: 0.0625rem solid var(--gentle-stroke);
-  border-left-width: 0;
-  border-right-width: 0;
+  border-top: 0.0625rem solid var(--gentle-stroke);
   box-shadow: none;
   min-height: var(--chat-input-wrapper-height);
   align-items: center;


### PR DESCRIPTION
resolves: https://www.notion.so/daostack/Remove-bottom-margin-line-separator-mobile-7f654803da3a441e873d63f0b0275ca1?pvs=4

### What was changed?
- [x] Chat input: remove bottom border
