### PR TITLE
Fix replied message text color in group\direct messages light mode

### DIFF
--- a/src/shared/components/Chat/ChatMessage/DMChatMessage.tsx
+++ b/src/shared/components/Chat/ChatMessage/DMChatMessage.tsx
@@ -306,6 +306,8 @@ export default function DMChatMessage({
               styles.messageContent,
               styles.replyMessageContent,
               {
+                [styles.replyMessageContentNotCurrentUser]:
+                  isNotCurrentUserMessage,
                 [styles.replyMessageContentWithImage]: image,
                 [styles.replyMessageContentWithFile]: file,
                 [styles.messageContentRtl]: isRtlWithNoMentions(


### PR DESCRIPTION
Ticket

- [x] PR title equals to the ticket name
- [x] I've added the link to task above in `Ticket`

### What was changed?
- [x] Updated the color of the replied message text in the DM or group chat if the message is not a user message