### PR TITLE
New condition to show unseen message tag

### DIFF
--- a/src/pages/common/components/FeedCard/components/FeedCardTags/FeedCardTags.tsx
+++ b/src/pages/common/components/FeedCard/components/FeedCardTags/FeedCardTags.tsx
@@ -52,7 +52,9 @@ export const FeedCardTags: FC<FeedCardTagsProps> = (props) => {
       {seenOnce && !unreadMessages && isPinned && (
         <PinIcon className={classNames(styles.pin)} />
       )}
-      {hasUnseenMention && <div className={styles.hasUnseenMention}>@</div>}
+      {(unreadMessages || isUnseenTagVisible) && hasUnseenMention && (
+        <div className={styles.hasUnseenMention}>@</div>
+      )}
       {isFollowing && (
         <StarIcon
           className={classNames(styles.starIcon)}


### PR DESCRIPTION
resolves: https://www.notion.so/daostack/Change-mention-indication-expiry-ba18886b135f413da7a2722d63ff85c7?pvs=4

### What was changed?
- [x] New condition to show unseen message tag
