### PR TITLE
show 'mark as unread' if data hasn't fetched yet

### DIFF
--- a/src/pages/common/components/DiscussionFeedCard/utils/getAllowedItems.ts
+++ b/src/pages/common/components/DiscussionFeedCard/utils/getAllowedItems.ts
@@ -33,6 +33,10 @@ const MENU_ITEM_TO_CHECK_FUNCTION_MAP: Record<
   [FeedItemMenuItem.MarkUnread]: ({ feedItemUserMetadata }) => {
     const { count, seen, isSeenUpdating } = feedItemUserMetadata || {};
 
+    if (!feedItemUserMetadata) {
+      return true;
+    }
+
     if (isSeenUpdating) {
       return false;
     }

--- a/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
+++ b/src/pages/commonFeed/components/FeedLayout/FeedLayout.tsx
@@ -785,7 +785,6 @@ const FeedLayout: ForwardRefRenderFunction<FeedLayoutRef, FeedLayoutProps> = (
                         commonName={commonData?.name || ""}
                         commonImage={commonData?.image || ""}
                         commonNotion={outerCommon?.notion}
-                        commonMember={commonMember}
                         pinnedFeedItems={outerCommon?.pinnedFeedItems}
                         isProject={commonData?.isProject}
                         isPinned={isPinned}


### PR DESCRIPTION
resolves: https://www.notion.so/daostack/Unread-option-doesn-t-appear-in-action-menu-at-first-10dddc0c6fa2446cb96d8419eebe025e?pvs=4

### What was changed?
- [x] feed items: show 'mark as unread' if data hasn't fetched yet
- [x] remove duplicated `commonMember={commonMember}` prop in `<FeedItem />` in `FeedLayout.tsx`
