### PR TITLE
fix: role inheritance - wrong message on how to join

### DIFF
--- a/src/pages/commonFeed/CommonFeed.tsx
+++ b/src/pages/commonFeed/CommonFeed.tsx
@@ -387,7 +387,7 @@ const CommonFeedComponent: FC<CommonFeedProps> = (props) => {
 
   useEffect(() => {
     fetchUserRelatedData();
-  }, [userId]);
+  }, [userId, parentCommonId]);
 
   useEffect(() => {
     if (!commonFeedItems && !areCommonFeedItemsLoading) {


### PR DESCRIPTION
resolves: https://www.notion.so/daostack/Role-inheritance-wrong-message-on-how-to-join-f721b353f5a446bea86f11e867c46839?pvs=4

### What was changed?
- [x] fix: role inheritance - wrong message on how to join
