### PR TITLE
Couldn't come back to write message focus after mention

### DIFF
--- a/src/shared/ui-kit/TextEditor/BaseTextEditor.tsx
+++ b/src/shared/ui-kit/TextEditor/BaseTextEditor.tsx
@@ -287,10 +287,27 @@ const BaseTextEditor: FC<TextEditorProps> = (props) => {
     }
   };
 
+  const handleMentionSelectionChange = useCallback(() => {
+    if (!editor.selection || editor.selection.anchor.path.length <= 2) {
+      return;
+    }
+
+    const { anchor } = editor.selection;
+    const point: BaseRange["anchor"] = {
+      ...anchor,
+      path: [anchor.path[0], anchor.path[1] + 1],
+    };
+    Transforms.select(editor, {
+      anchor: point,
+      focus: point,
+    });
+  }, []);
+
   const handleOnChange = useCallback(
     (updatedContent) => {
       // Prevent update for cursor clicks
       if (isEqual(updatedContent, value)) {
+        handleMentionSelectionChange();
         return;
       }
       onChange && onChange(updatedContent);
@@ -298,7 +315,7 @@ const BaseTextEditor: FC<TextEditorProps> = (props) => {
 
       handleOnChangeSelection(selection);
     },
-    [onChange, value],
+    [onChange, value, handleMentionSelectionChange],
   );
 
   return (


### PR DESCRIPTION
[Ticket](https://www.notion.so/daostack/Couldn-t-come-back-to-write-message-focus-after-mention-cc0daca369f349cdafafda74c6ff4694)

- [x] PR title equals to the ticket name
- [x] I've added the link to task above in `Ticket`

### What was changed?
- [x] added workaround for correct caret position for the case when we are focusing editor again clicking mention text
