### PR TITLE
Fix mobile chat scroll issue

### DIFF
--- a/src/shared/components/Modal/index.scss
+++ b/src/shared/components/Modal/index.scss
@@ -145,6 +145,7 @@ $modal-mobile-padding: 1.5rem;
   .modal__content {
     flex: 1;
     padding: 0 $modal-padding;
+    overflow-y: auto;
 
     @include big-phone {
       padding-left: $modal-mobile-padding;


### PR DESCRIPTION
Ticket: https://www.notion.so/daostack/Mobile-scroll-issue-in-the-chat-897ad6d03bb1489db43663b098ed3e0f?pvs=4

- [ ] PR title equals to the ticket name
- [ ] I've added the link to task above in `Ticket`

### What was changed?
- [ ] reverted the removal of "overflow-y" line in shared components css
